### PR TITLE
feat: streaming engine, GC-optimized reconciler, benchmarks, and perf…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,10 @@ type CSVParserCfg struct {
 	CurrencyCol string `yaml:"currency_col,omitempty"`
 	NameCol     string `yaml:"name_col,omitempty"`
 	RefCol      string `yaml:"ref_col,omitempty"`
+	// SkipRaw skips the per-row Raw map[string]string allocation.
+	// Set to true for large files to reduce allocator pressure.
+	// Default false preserves the Raw field on every Transaction.
+	SkipRaw bool `yaml:"skip_raw,omitempty"`
 }
 
 // Pair defines a reconciliation pair configuration

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,428 @@
+# Reconify Engine Performance
+
+This document explains how the streaming reconciliation engine is designed, what
+performance numbers it achieves, why it behaves the way it does at scale, and how
+to select hardware for your workload.
+
+---
+
+## How the Engine Works
+
+The reconciler processes two transaction files without loading both into memory
+at the same time. The right-side file is indexed once into a hash map. The
+left-side file is then streamed and matched against that index row by row. Results
+are emitted as events and written to the output format immediately. Peak memory is
+determined by the size of the right-side index, not the combined file sizes.
+
+```mermaid
+flowchart TD
+    A[right.csv] -->|stream row by row| B[ParseCSVEach\nPass 1]
+    B -->|Add compact bucket| C[(RightIndex\nmemoryIndex)]
+    B --> D[rightSeen\nmap string uint8\nsaturating counter]
+    D -->|any duplicates?| E{len > 0}
+    E -->|yes| F[collectDuplicates\ntargeted right re-scan]
+    E -->|no| G((skip\nno extra I/O))
+
+    H[left.csv] -->|stream row by row| I[ParseCSVEach\nPass 2]
+    C -->|Get buckets by ref| I
+    I --> J{outcome per row}
+    J -->|ref + amount + date match| K[WriteMatch]
+    J -->|ref + date match, amount diff| L[WriteAmountDiff]
+    J -->|ref + amount match, date diff| M[WriteTimingDiff]
+    J -->|no matching bucket| N[WriteUnmatched left]
+    I --> O[leftSeen\nmap string uint8]
+    O -->|any duplicates?| P{len > 0}
+    P -->|yes| Q[collectDuplicates\ntargeted left re-scan]
+    P -->|no| R((skip))
+
+    C -->|IterateUnused| S[WriteUnmatched right]
+
+    K --> T[ResultWriter]
+    L --> T
+    M --> T
+    N --> T
+    S --> T
+    F --> T
+    Q --> T
+    T -->|flush| U[output\nndjson / json / csv / table]
+```
+
+### The three stages
+
+**Stage 1: index the right side.** `ParseCSVEach` streams through `right.csv`.
+Each row is stored in the `RightIndex` as a compact `bucket` struct containing flat
+integer fields (no `time.Time`, no duplicate reference string). Reference occurrence
+counts are tracked using a saturating `uint8` counter capped at 2.
+
+**Stage 2: match the left side.** `ParseCSVEach` streams through `left.csv`. For
+each row the engine calls `idx.Get(ref)` for an O(1) bucket lookup. Matches, amount
+diffs, timing diffs, and unmatched left rows are emitted immediately to the
+`ResultWriter`. Left reference counts are tracked with the same saturating counter.
+
+**Stage 3 (conditional): collect duplicates.** If any reference appeared more than
+once on either side, the engine re-scans that file a second time and collects only
+the rows whose reference was flagged. For datasets with no duplicates this stage is
+never invoked and costs zero I/O.
+
+The `ResultWriter` supports five output formats. `ndjson` and `csv` write one line
+per event and use O(1) memory regardless of result size. `json` accumulates all
+results in memory before flushing and is intended for smaller datasets or API
+integration.
+
+---
+
+## Benchmark Environment
+
+All numbers in this document were collected on an Apple M1 Pro (10-core, 32 GB
+unified memory, NVMe SSD) running macOS with Go 1.24.0.
+
+The dataset contains 20 million rows per side, split across two CSV files with
+different column schemas (left uses `ref_id`/`description`; right uses
+`txn_ref`/`merchant`). File sizes: left.csv ~1.23 GB, right.csv ~991 MB.
+
+The outcome distribution reflects realistic financial reconciliation workloads:
+
+| Outcome | Share |
+|---|---|
+| Perfect match (ref + amount + date) | 85% |
+| Amount difference (1-50 minor units) | 5% |
+| Timing difference (1-3 days) | 5% |
+| Unmatched left only | 5% |
+| Unmatched right only | 5% |
+
+---
+
+## Parse Throughput
+
+Parsing is not the bottleneck. The 1 MB read buffer and a date-string cache (capped
+at 1000 keys) keep allocation low and keep `encoding/csv` from dominating.
+
+| Benchmark | Rows | Time | Throughput |
+|---|---|---|---|
+| `ParseCSVEach` 100k synthetic | 100,000 | ~58 ms | ~1.7 M rows/sec |
+| `ParseCSVEach` 20M realistic (warm cache) | 20,000,000 | ~8.5 s | ~2.35 M rows/sec |
+
+These numbers are I/O and CSV-decode bound. They will not improve further without
+moving to zero-copy or SIMD-accelerated parsing (a Rust concern, not a Go one).
+
+---
+
+## Reconciliation Throughput Across Optimization Generations
+
+```mermaid
+xychart-beta
+    title "Wall Clock Time: 20M x 20M Reconciliation"
+    x-axis ["Baseline", "v5: no leftFirst", "v6: compact bucket"]
+    y-axis "Seconds" 0 --> 600
+    bar [537, 148, 171]
+```
+
+```mermaid
+xychart-beta
+    title "Peak RSS: 20M x 20M Reconciliation"
+    x-axis ["Baseline", "v5: no leftFirst", "v6: compact bucket"]
+    y-axis "RSS (GB)" 0 --> 10
+    bar [7.6, 7.6, 6.2]
+```
+
+| Version | Wall clock | Peak RSS | Worst GC mark | Approx. rows/sec |
+|---|---|---|---|---|
+| Baseline | 537 s | 7.6 GB | ~48 s | ~29k |
+| v5: eliminate `leftFirst`/`rightFirst` | 148 s | 7.6 GB | ~20 s | ~105k |
+| v6: compact `bucket` struct | 171 s | 6.2 GB | ~15 s | ~91k |
+
+The wall-clock numbers have run-to-run variance of roughly 15-20% on macOS due to
+thermal throttling and OS scheduling. The RSS measurement is the stable signal.
+The v5 to v6 regression in wall-clock time is within that variance band; the RSS
+drop from 7.6 GB to 6.2 GB is real and reproducible.
+
+---
+
+## Why Throughput Collapses at 20M Scale
+
+### The engine is not CPU-bound. It is GC-bound.
+
+At 1M rows the right-side index fits largely within L3 cache (typically 8-32 MB on
+modern processors). Hash lookups are fast, GC cycles are short, and throughput
+reaches ~320k rows/sec.
+
+At 20M rows three effects compound each other.
+
+**Cache miss explosion.** The right-side index grows to 4-6 GB. Every reference
+lookup on the left side now misses L3 cache and stalls the CPU waiting for main
+memory. This alone reduces throughput by 2-3x compared to the cache-warm case.
+
+**Heap scanning explosion.** Go's garbage collector uses a concurrent tricolor mark
+algorithm. During each GC cycle the collector traces every live pointer in the heap.
+The duration of the mark phase is proportional to the number of pointer fields in
+live objects, not just total heap size. Maps with pointer-rich struct values are the
+worst case for this algorithm.
+
+**Mark phase duration.** At baseline the GC took up to 48 seconds for a single
+concurrent mark phase at 20M scale. This is not stop-the-world time. The
+application continues running while the collector marks. But marking consumes CPU
+cores, taking them away from the reconciler and causing the 10x throughput drop from
+1M to 20M rows (320k rows/sec down to 29k rows/sec).
+
+### The root cause: `leftFirst map[string]Transaction`
+
+Before any optimization the reconciler stored a full `Transaction` value for every
+unique reference seen on the left side:
+
+```
+leftFirst  map[string]Transaction   // 20M entries x ~232 bytes = ~4.6 GB
+rightFirst map[string]Transaction   // similar, depending on right-side duplication
+```
+
+Each `Transaction` held five string fields. Each string is a 16-byte header pointing
+to a separate heap allocation. That is approximately 100 million live pointer fields
+that the GC had to follow during every collection cycle. This is the 48-second mark
+phase.
+
+The critical detail: **both maps were used only for duplicate detection, never for
+matching**. The matching algorithm accessed neither `leftFirst` nor `rightFirst`.
+
+---
+
+## Optimization History
+
+### v5: Eliminate `leftFirst` and `rightFirst`
+
+Duplicate detection only needs to know whether a reference appeared more than once,
+not what the full transaction looked like. The v5 optimization replaces both large
+maps with two small structures per side:
+
+- `leftSeen map[string]uint8`: a saturating counter capped at 2 (0 = unseen, 1 = seen
+  once, 2 = seen at least twice)
+- `leftDupRefs map[string]bool`: the set of references flagged as duplicates
+
+When duplicates are found, `collectDuplicates` re-scans the file and collects only
+the rows whose reference is in `leftDupRefs`. This costs one extra sequential file
+read. Sequential I/O on NVMe at 1-2 GB/sec makes this a small fraction of total run
+time compared to the GC savings.
+
+```mermaid
+flowchart LR
+    subgraph before ["Before v5: live heap at peak"]
+        direction TB
+        B1["rightIndex\n~4 GB"]
+        B2["leftFirst\n~4.6 GB\nCULPRIT"]
+        B3["rightFirst\n~1.5 GB"]
+        B4["leftRefCount\n~640 MB"]
+        B5["rightRefCount\n~640 MB"]
+        B6["runtime + OS\n~1 GB"]
+        B7["TOTAL: ~12 GB"]
+    end
+
+    subgraph after ["After v5: live heap at peak"]
+        direction TB
+        A1["rightIndex\n~4 GB"]
+        A2["leftSeen\n~500 MB"]
+        A3["rightSeen\n~500 MB"]
+        A4["runtime + OS\n~1 GB"]
+        A5["TOTAL: ~6 GB"]
+    end
+
+    before -->|"3.6x faster wall clock\n44% less total alloc"| after
+```
+
+Results at 20M x 20M: wall clock 537s to 148s (3.6x), TotalAlloc 43.5 GB to 24.2
+GB, worst GC mark 48s to 20s. Peak RSS unchanged at 7.6 GB because the right-side
+index still dominated.
+
+### v6: Compact the `bucket` struct
+
+After v5 the right-side index held a full `Transaction` inside each bucket. The
+`Transaction` type contained a `time.Time` field (which internally stores a
+`*Location` pointer) and a `Reference` string that duplicated the map key. At 20M
+entries that was 40 million extra pointer fields in the GC scan graph.
+
+The `bucket` struct was refactored to store flat integer fields only:
+
+```go
+type bucket struct {
+    id       string
+    dateUnix int64   // time.UnixNano() -- no *Location pointer
+    amount   int64
+    currency string
+    name     string
+    source   string
+    used     bool
+}
+```
+
+`Reference` is injected from the map key when constructing a `Transaction` for
+output via `b.toTransaction(ref)`. `Date` is stored as nanoseconds and reconstructed
+via `time.Unix(0, b.dateUnix).UTC()` only at output time. The matching loop caches
+`ltx.Date.UnixNano()` once per left row and compares integers:
+
+```go
+ltxDateNano := ltx.Date.UnixNano()
+daysDiff := daysBetweenNano(ltxDateNano, b.dateUnix)
+```
+
+This avoids allocating `time.Duration` and calling `.Hours()` for every bucket
+comparison on the hot path.
+
+Results at 20M x 20M: Peak RSS 7.6 GB to 6.2 GB (18% reduction), worst GC mark
+20s to 15s.
+
+---
+
+## Memory at Peak During Reconciliation
+
+```mermaid
+flowchart TD
+    subgraph ram ["RAM contents during Pass 2 - peak usage point"]
+        direction LR
+        I["RightIndex\n20M compact buckets\n4-6 GB\n(dominant)"]
+        LS["leftSeen\n20M string keys\n~500 MB"]
+        RS["rightSeen\n20M string keys\n~500 MB"]
+        RT["Go runtime\ngoroutines, GC metadata\n~300 MB"]
+        BUF["I/O buffers\nCSV read buffer 1 MB\nnegligible"]
+        OUT["Output buffer\nndjson: O(1)\njson: O(results)"]
+    end
+```
+
+The right index is the ceiling. The left and right `Seen` maps are substantial but
+secondary. Everything else is negligible at 20M scale.
+
+The right index size depends on the average string content in your data. Each bucket
+stores four string fields (`id`, `currency`, `name`, `source`). Short identifiers
+and three-character currency codes bring the per-bucket cost toward 150 bytes; long
+UUIDs and verbose merchant names push it toward 300 bytes. The map structure itself
+adds roughly 50-60 bytes per entry regardless.
+
+---
+
+## Hardware Requirements
+
+### RAM formula
+
+The right-side index dominates peak memory. The formula below gives a conservative
+estimate for hardware planning:
+
+```
+RAM_required_GB = ceil( (R x B_right + L x 60) / 1_000_000_000 + 2.0 )
+```
+
+Where:
+
+| Symbol | Meaning |
+|---|---|
+| `R` | Number of rows in the right-side file |
+| `B_right` | Bytes per right-side row in the index (see table below) |
+| `L` | Number of rows in the left-side file |
+| `60` | Bytes per left-side entry in the `leftSeen` tracking map |
+| `2.0 GB` | Fixed overhead: Go runtime, OS buffers, output, safety margin |
+
+`B_right` depends on the average length of the string fields in your data:
+
+| Field profile | `B_right` |
+|---|---|
+| Short IDs (under 12 chars), 3-char currency codes | 150 |
+| Typical (20-char IDs, short descriptions) | 220 |
+| Long (UUID IDs, verbose merchant names) | 300 |
+
+For conservative hardware planning use `B_right = 300`.
+
+```mermaid
+flowchart LR
+    R["R = right-side rows"] --> RCALC["R x B_right bytes"]
+    L["L = left-side rows"] --> LCALC["L x 60 bytes"]
+    RCALC --> SUM["sum both sides"]
+    LCALC --> SUM
+    SUM --> DIV["divide by 1,000,000,000\nconvert to GB"]
+    DIV --> ADD["add 2 GB fixed overhead"]
+    ADD --> CEIL["round up to next integer"]
+    CEIL --> OUT["RAM required in GB"]
+```
+
+**Example: 20M right rows, 20M left rows, typical string lengths (B_right = 220)**
+
+```
+RAM = ceil( (20_000_000 x 220 + 20_000_000 x 60) / 1_000_000_000 + 2.0 )
+    = ceil( (4_400_000_000 + 1_200_000_000) / 1_000_000_000 + 2.0 )
+    = ceil( 5.6 + 2.0 )
+    = ceil( 7.6 )
+    = 8 GB
+```
+
+Observed peak RSS in benchmarks: 6.2 GB. The formula over-estimates slightly to
+account for Go allocator overhead and GC live-set bookkeeping.
+
+### Reference table
+
+```mermaid
+flowchart TD
+    A["How many rows on the right side?"] --> B{"R <= 5M"}
+    B -->|yes| C["4 GB RAM\ncomfortable headroom"]
+    B -->|no| D{"R <= 15M"}
+    D -->|yes| E["8 GB RAM"]
+    D -->|no| F{"R <= 30M"}
+    F -->|yes| G["16 GB RAM"]
+    F -->|no| H{"R <= 60M"}
+    H -->|yes| I["32 GB RAM"]
+    H -->|no| J["64+ GB RAM\nor use a disk-backed RightIndex\n(SQLite, mmap)"]
+```
+
+| Right rows | Left rows | B_right=150 | B_right=220 | B_right=300 | Recommended RAM |
+|---|---|---|---|---|---|
+| 1M | 1M | 0.3 GB | 0.3 GB | 0.4 GB | 4 GB |
+| 5M | 5M | 1.1 GB | 1.4 GB | 1.8 GB | 4 GB |
+| 10M | 10M | 2.1 GB | 2.8 GB | 3.6 GB | 8 GB |
+| 20M | 20M | 4.2 GB | 5.6 GB | 7.2 GB | 16 GB |
+| 50M | 50M | 10.5 GB | 14 GB | 18 GB | 32 GB |
+| 100M | 100M | 21 GB | 28 GB | 36 GB | 64 GB |
+
+Recommended RAM adds a 2x safety margin over the formula output to account for GC
+live-set overhead and OS memory pressure. If the right side does not fit in RAM,
+implement `RightIndex` backed by SQLite or a memory-mapped file and pass it to
+`ReconcileStreaming`; the reconciler is decoupled from the index implementation.
+
+### CPU
+
+Parsing and reconciliation are single-threaded. A single fast core matters more
+than core count. Any modern processor running at 2.5 GHz or above is sufficient.
+The current engine does not benefit from additional cores.
+
+### Disk
+
+Input files are read sequentially. The right file is read once per run (twice in
+the rare case where duplicate references are detected). No intermediate files are
+written.
+
+Sequential read bandwidth at 20M rows (approximately 2.2 GB combined) with a warm
+OS page cache is negligible. Cold cache adds approximately:
+
+| Storage type | Additional time |
+|---|---|
+| NVMe SSD | 0.5 to 2 seconds |
+| SATA SSD | 2 to 5 seconds |
+| Spinning disk (HDD) | 10 to 30 seconds |
+
+---
+
+## What Comes Next
+
+The remaining pointer density in the right-side index comes from four string fields
+per bucket (`id`, `currency`, `name`, `source`). The next optimization levers, in
+order of impact, are:
+
+**Currency interning.** Typical datasets contain 3 to 5 distinct currency codes.
+Replacing the `currency string` field with a `uint8` enum eliminates one pointer
+field per bucket. At 20M rows this saves roughly 200 MB of RSS and removes 20M
+pointer fields from the GC scan graph.
+
+**ID lazy reconstruction.** Store only a `rowNum uint32` in the bucket instead of
+the `id string`. Reconstruct the ID by seeking to the source row only when
+generating output events. This eliminates one more pointer field per bucket but
+adds I/O on the output path, so it is only beneficial when the match rate is high
+(few unmatched events per total rows processed).
+
+**Hard ceiling in Go.** The practical ceiling for this design in Go is approximately
+80 to 120k rows/sec at 20M scale with peak RSS around 4 to 5 GB. Below that floor,
+the fundamental cost of 20M hash map entries with string keys and Go's
+pointer-tracing GC sets a hard limit that no further struct compaction will break
+through. A Rust implementation with arena-allocated structs and no GC would provide
+a step-change improvement at that point.

--- a/engine/format.go
+++ b/engine/format.go
@@ -1,0 +1,519 @@
+package engine
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"text/tabwriter"
+	"time"
+)
+
+// ResultWriter receives reconciliation events and writes them to an output format.
+//
+// Not thread-safe. Must be called from a single goroutine.
+// Flush() must be called exactly once after all events have been written.
+type ResultWriter interface {
+	WriteMatch(pair MatchedPair) error
+	WriteAmountDiff(pair AmountDiffPair) error
+	WriteTimingDiff(pair TimingDiffPair) error
+	// WriteUnmatched writes an unmatched transaction. side must be "left" or "right".
+	WriteUnmatched(tx Transaction, side string) error
+	WriteDuplicate(group DuplicateGroup) error
+	WriteSummary(s Summary) error
+	// Flush finalizes the output (closes JSON arrays/objects, flushes CSV buffers,
+	// renders table). Must be called exactly once after all events.
+	Flush() error
+}
+
+// NewResultWriter returns a ResultWriter for the given format name.
+// Valid formats: "json", "json-stream", "ndjson", "csv", "table".
+func NewResultWriter(format string, w io.Writer) (ResultWriter, error) {
+	switch format {
+	case "json":
+		return newJSONWriter(w), nil
+	case "json-stream":
+		return newJSONStreamWriter(w), nil
+	case "ndjson":
+		return newNDJSONWriter(w), nil
+	case "csv":
+		return newCSVWriter(w), nil
+	case "table":
+		return newTableWriter(w), nil
+	default:
+		return nil, fmt.Errorf("unknown format %q (valid: json, json-stream, ndjson, csv, table)", format)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSONWriter — buffers full Result struct, writes indented JSON on Flush().
+// Byte-identical to current reconcile output. Not streaming-friendly for large files.
+// ---------------------------------------------------------------------------
+
+type jsonWriter struct {
+	w      io.Writer
+	result Result
+}
+
+func newJSONWriter(w io.Writer) *jsonWriter { return &jsonWriter{w: w} }
+
+func (j *jsonWriter) WriteMatch(pair MatchedPair) error {
+	j.result.Matched = append(j.result.Matched, pair)
+	return nil
+}
+func (j *jsonWriter) WriteAmountDiff(pair AmountDiffPair) error {
+	j.result.AmountDiff = append(j.result.AmountDiff, pair)
+	return nil
+}
+func (j *jsonWriter) WriteTimingDiff(pair TimingDiffPair) error {
+	j.result.TimingDiff = append(j.result.TimingDiff, pair)
+	return nil
+}
+func (j *jsonWriter) WriteUnmatched(tx Transaction, side string) error {
+	if side == "left" {
+		j.result.UnmatchedLeft = append(j.result.UnmatchedLeft, tx)
+	} else {
+		j.result.UnmatchedRight = append(j.result.UnmatchedRight, tx)
+	}
+	return nil
+}
+func (j *jsonWriter) WriteDuplicate(group DuplicateGroup) error {
+	j.result.Duplicates = append(j.result.Duplicates, group)
+	return nil
+}
+func (j *jsonWriter) WriteSummary(s Summary) error {
+	j.result.Summary = s
+	return nil
+}
+func (j *jsonWriter) Flush() error {
+	enc := json.NewEncoder(j.w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(j.result)
+}
+
+// GetResult returns the accumulated Result. Useful for callers that need the
+// struct directly (e.g. the Reconcile wrapper).
+func (j *jsonWriter) GetResult() *Result { return &j.result }
+
+// ---------------------------------------------------------------------------
+// JSONStreamWriter — buffers JSON bytes per section; immediate encoding on
+// each event. More GC-friendly than JSONWriter since Go structs are released
+// after encoding. Structurally identical output to JSONWriter.
+//
+// Note: if the process is interrupted mid-stream, output will be invalid JSON
+// (unclosed arrays/object). NDJSON does not have this problem — each line is
+// independently valid. For crash-safe output, prefer --format=ndjson.
+// ---------------------------------------------------------------------------
+
+type jsonStreamSection struct {
+	key    string
+	events []json.RawMessage
+}
+
+type jsonStreamWriter struct {
+	w        io.Writer
+	meta     struct{ PairName, LeftSource, RightSource string }
+	sections []jsonStreamSection // ordered; keyed by JSON field name
+	byKey    map[string]*jsonStreamSection
+	summary  *Summary
+}
+
+func newJSONStreamWriter(w io.Writer) *jsonStreamWriter {
+	order := []string{"matched", "unmatched_left", "unmatched_right", "amount_diff", "timing_diff", "duplicates"}
+	jw := &jsonStreamWriter{
+		w:     w,
+		byKey: make(map[string]*jsonStreamSection, len(order)),
+	}
+	for _, k := range order {
+		sec := &jsonStreamSection{key: k}
+		jw.sections = append(jw.sections, *sec)
+	}
+	// rebuild map from slice to point to slice elements
+	for i := range jw.sections {
+		jw.byKey[jw.sections[i].key] = &jw.sections[i]
+	}
+	return jw
+}
+
+func (j *jsonStreamWriter) encode(v any) (json.RawMessage, error) {
+	b, err := json.Marshal(v)
+	return json.RawMessage(b), err
+}
+
+func (j *jsonStreamWriter) appendTo(key string, v any) error {
+	b, err := j.encode(v)
+	if err != nil {
+		return err
+	}
+	j.byKey[key].events = append(j.byKey[key].events, b)
+	return nil
+}
+
+func (j *jsonStreamWriter) WriteMatch(pair MatchedPair) error {
+	return j.appendTo("matched", pair)
+}
+func (j *jsonStreamWriter) WriteAmountDiff(pair AmountDiffPair) error {
+	return j.appendTo("amount_diff", pair)
+}
+func (j *jsonStreamWriter) WriteTimingDiff(pair TimingDiffPair) error {
+	return j.appendTo("timing_diff", pair)
+}
+func (j *jsonStreamWriter) WriteUnmatched(tx Transaction, side string) error {
+	if side == "left" {
+		return j.appendTo("unmatched_left", tx)
+	}
+	return j.appendTo("unmatched_right", tx)
+}
+func (j *jsonStreamWriter) WriteDuplicate(group DuplicateGroup) error {
+	return j.appendTo("duplicates", group)
+}
+func (j *jsonStreamWriter) WriteSummary(s Summary) error {
+	j.summary = &s
+	return nil
+}
+func (j *jsonStreamWriter) Flush() error {
+	// Build a result-shaped object from accumulated raw messages.
+	// All sections are always present; missing ones output as empty arrays.
+	result := map[string]any{
+		"pair":         j.meta.PairName,
+		"left_source":  j.meta.LeftSource,
+		"right_source": j.meta.RightSource,
+	}
+	if j.summary != nil {
+		result["summary"] = j.summary
+	} else {
+		result["summary"] = Summary{}
+	}
+	for _, sec := range j.sections {
+		if len(sec.events) == 0 {
+			result[sec.key] = []json.RawMessage{}
+		} else {
+			result[sec.key] = sec.events
+		}
+	}
+	enc := json.NewEncoder(j.w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+// SetMeta sets the pair/source metadata for the JSON output.
+func (j *jsonStreamWriter) SetMeta(pairName, leftSource, rightSource string) {
+	j.meta.PairName = pairName
+	j.meta.LeftSource = leftSource
+	j.meta.RightSource = rightSource
+}
+
+// ---------------------------------------------------------------------------
+// NDJSONWriter — one tagged JSON envelope per event, immediately written.
+// O(1) memory. Crash-safe: each line is independently valid JSON.
+// ---------------------------------------------------------------------------
+
+type ndjsonWriter struct {
+	enc *json.Encoder
+}
+
+func newNDJSONWriter(w io.Writer) *ndjsonWriter {
+	return &ndjsonWriter{enc: json.NewEncoder(w)}
+}
+
+type ndjsonEnvelope struct {
+	Type string `json:"type"`
+	Data any    `json:"data"`
+}
+
+func (n *ndjsonWriter) emit(typ string, data any) error {
+	return n.enc.Encode(ndjsonEnvelope{Type: typ, Data: data})
+}
+
+func (n *ndjsonWriter) WriteMatch(pair MatchedPair) error        { return n.emit("match", pair) }
+func (n *ndjsonWriter) WriteAmountDiff(pair AmountDiffPair) error { return n.emit("amount_diff", pair) }
+func (n *ndjsonWriter) WriteTimingDiff(pair TimingDiffPair) error { return n.emit("timing_diff", pair) }
+func (n *ndjsonWriter) WriteUnmatched(tx Transaction, side string) error {
+	return n.emit("unmatched_"+side, tx)
+}
+func (n *ndjsonWriter) WriteDuplicate(group DuplicateGroup) error { return n.emit("duplicate", group) }
+func (n *ndjsonWriter) WriteSummary(s Summary) error              { return n.emit("summary", s) }
+func (n *ndjsonWriter) Flush() error                              { return nil }
+
+// ---------------------------------------------------------------------------
+// CSVWriter — fixed schema, one row per event. O(1) memory. Versioned contract.
+//
+// Column order:
+//   type, left_id, left_date, left_amount_minor, left_ref, left_name,
+//   right_id, right_date, right_amount_minor, right_ref, right_name,
+//   diff_minor, days_diff,
+//   source, reference, dup_count,
+//   total_left, total_right, matched, unmatched_left, unmatched_right,
+//   amount_diff_count, timing_diff_count, duplicate_count, match_rate_pct
+//
+// Unused columns for a given event type are empty string.
+// ---------------------------------------------------------------------------
+
+var csvHeader = []string{
+	"type",
+	"left_id", "left_date", "left_amount_minor", "left_ref", "left_name",
+	"right_id", "right_date", "right_amount_minor", "right_ref", "right_name",
+	"diff_minor", "days_diff",
+	"source", "reference", "dup_count",
+	"total_left", "total_right", "matched", "unmatched_left", "unmatched_right",
+	"amount_diff_count", "timing_diff_count", "duplicate_count", "match_rate_pct",
+}
+
+type csvWriter struct {
+	w       *csv.Writer
+	started bool
+}
+
+func newCSVWriter(w io.Writer) *csvWriter {
+	return &csvWriter{w: csv.NewWriter(w)}
+}
+
+func (c *csvWriter) writeHeader() error {
+	if c.started {
+		return nil
+	}
+	c.started = true
+	return c.w.Write(csvHeader)
+}
+
+// emptyRow returns a slice of empty strings with len == len(csvHeader).
+func emptyRow(typ string) []string {
+	row := make([]string, len(csvHeader))
+	row[0] = typ
+	return row
+}
+
+func fmtDate(t time.Time) string { return t.Format(time.RFC3339) }
+func fmtI64(v int64) string      { return strconv.FormatInt(v, 10) }
+func fmtInt(v int) string        { return strconv.Itoa(v) }
+
+func txLeft(row []string, tx Transaction) {
+	row[1] = tx.ID
+	row[2] = fmtDate(tx.Date)
+	row[3] = fmtI64(tx.Amount)
+	row[4] = tx.Reference
+	row[5] = tx.Name
+}
+
+func txRight(row []string, tx Transaction) {
+	row[6] = tx.ID
+	row[7] = fmtDate(tx.Date)
+	row[8] = fmtI64(tx.Amount)
+	row[9] = tx.Reference
+	row[10] = tx.Name
+}
+
+func (c *csvWriter) WriteMatch(pair MatchedPair) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	row := emptyRow("match")
+	txLeft(row, pair.Left)
+	txRight(row, pair.Right)
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) WriteAmountDiff(pair AmountDiffPair) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	row := emptyRow("amount_diff")
+	txLeft(row, pair.Left)
+	txRight(row, pair.Right)
+	row[11] = fmtI64(pair.DiffMinor)
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) WriteTimingDiff(pair TimingDiffPair) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	row := emptyRow("timing_diff")
+	txLeft(row, pair.Left)
+	txRight(row, pair.Right)
+	row[12] = fmtInt(pair.DaysDiff)
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) WriteUnmatched(tx Transaction, side string) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	typ := "unmatched_" + side
+	row := emptyRow(typ)
+	if side == "left" {
+		txLeft(row, tx)
+	} else {
+		txRight(row, tx)
+	}
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) WriteDuplicate(group DuplicateGroup) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	row := emptyRow("duplicate")
+	row[13] = group.Source
+	row[14] = group.Reference
+	row[15] = fmtInt(len(group.Transactions))
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) WriteSummary(s Summary) error {
+	if err := c.writeHeader(); err != nil {
+		return err
+	}
+	row := emptyRow("summary")
+	row[16] = fmtInt(s.TotalLeft)
+	row[17] = fmtInt(s.TotalRight)
+	row[18] = fmtInt(s.MatchedCount)
+	row[19] = fmtInt(s.UnmatchedLeft)
+	row[20] = fmtInt(s.UnmatchedRight)
+	row[21] = fmtInt(s.AmountDiffCount)
+	row[22] = fmtInt(s.TimingDiffCount)
+	row[23] = fmtInt(s.DuplicateCount)
+	row[24] = strconv.FormatFloat(s.MatchRatePct, 'f', 2, 64)
+	return c.w.Write(row)
+}
+
+func (c *csvWriter) Flush() error {
+	c.w.Flush()
+	return c.w.Error()
+}
+
+// ---------------------------------------------------------------------------
+// TableWriter — buffers all rows, renders ASCII table via text/tabwriter on Flush().
+// Not suitable for large datasets: warns at tableWarnThreshold rows.
+// ---------------------------------------------------------------------------
+
+const tableWarnThreshold = 10_000
+
+type tableRow struct {
+	typ    string
+	leftID string
+	leftDt string
+	leftAmt string
+	leftRef string
+	rightID string
+	rightDt string
+	rightAmt string
+	rightRef string
+	note    string
+}
+
+type tableWriter struct {
+	w    io.Writer
+	rows []tableRow
+	warn bool
+}
+
+func newTableWriter(w io.Writer) *tableWriter { return &tableWriter{w: w} }
+
+func (t *tableWriter) maybeWarn() {
+	if !t.warn && len(t.rows) > tableWarnThreshold {
+		t.warn = true
+		fmt.Fprintf(t.w, "warning: table mode has buffered >%d rows; for large files use --format=ndjson or --format=csv\n", tableWarnThreshold)
+	}
+}
+
+func (t *tableWriter) WriteMatch(pair MatchedPair) error {
+	t.rows = append(t.rows, tableRow{
+		typ:      "match",
+		leftID:   pair.Left.ID,
+		leftDt:   pair.Left.Date.Format("2006-01-02"),
+		leftAmt:  fmtI64(pair.Left.Amount),
+		leftRef:  pair.Left.Reference,
+		rightID:  pair.Right.ID,
+		rightDt:  pair.Right.Date.Format("2006-01-02"),
+		rightAmt: fmtI64(pair.Right.Amount),
+		rightRef: pair.Right.Reference,
+	})
+	t.maybeWarn()
+	return nil
+}
+
+func (t *tableWriter) WriteAmountDiff(pair AmountDiffPair) error {
+	t.rows = append(t.rows, tableRow{
+		typ:      "amount_diff",
+		leftID:   pair.Left.ID,
+		leftDt:   pair.Left.Date.Format("2006-01-02"),
+		leftAmt:  fmtI64(pair.Left.Amount),
+		leftRef:  pair.Left.Reference,
+		rightID:  pair.Right.ID,
+		rightDt:  pair.Right.Date.Format("2006-01-02"),
+		rightAmt: fmtI64(pair.Right.Amount),
+		rightRef: pair.Right.Reference,
+		note:     "diff=" + fmtI64(pair.DiffMinor),
+	})
+	t.maybeWarn()
+	return nil
+}
+
+func (t *tableWriter) WriteTimingDiff(pair TimingDiffPair) error {
+	t.rows = append(t.rows, tableRow{
+		typ:      "timing_diff",
+		leftID:   pair.Left.ID,
+		leftDt:   pair.Left.Date.Format("2006-01-02"),
+		leftAmt:  fmtI64(pair.Left.Amount),
+		leftRef:  pair.Left.Reference,
+		rightID:  pair.Right.ID,
+		rightDt:  pair.Right.Date.Format("2006-01-02"),
+		rightAmt: fmtI64(pair.Right.Amount),
+		rightRef: pair.Right.Reference,
+		note:     "days=" + fmtInt(pair.DaysDiff),
+	})
+	t.maybeWarn()
+	return nil
+}
+
+func (t *tableWriter) WriteUnmatched(tx Transaction, side string) error {
+	row := tableRow{
+		typ:     "unmatched_" + side,
+		note:    "",
+	}
+	if side == "left" {
+		row.leftID = tx.ID
+		row.leftDt = tx.Date.Format("2006-01-02")
+		row.leftAmt = fmtI64(tx.Amount)
+		row.leftRef = tx.Reference
+	} else {
+		row.rightID = tx.ID
+		row.rightDt = tx.Date.Format("2006-01-02")
+		row.rightAmt = fmtI64(tx.Amount)
+		row.rightRef = tx.Reference
+	}
+	t.rows = append(t.rows, row)
+	t.maybeWarn()
+	return nil
+}
+
+func (t *tableWriter) WriteDuplicate(group DuplicateGroup) error {
+	t.rows = append(t.rows, tableRow{
+		typ:     "duplicate",
+		leftRef: group.Reference,
+		note:    "source=" + group.Source + " count=" + fmtInt(len(group.Transactions)),
+	})
+	t.maybeWarn()
+	return nil
+}
+
+func (t *tableWriter) WriteSummary(s Summary) error {
+	t.rows = append(t.rows, tableRow{
+		typ:  "summary",
+		note: fmt.Sprintf("matched=%d unmatched_left=%d unmatched_right=%d rate=%.1f%%", s.MatchedCount, s.UnmatchedLeft, s.UnmatchedRight, s.MatchRatePct),
+	})
+	return nil
+}
+
+func (t *tableWriter) Flush() error {
+	tw := tabwriter.NewWriter(t.w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "TYPE\tLEFT_ID\tLEFT_DATE\tLEFT_AMT\tLEFT_REF\tRIGHT_ID\tRIGHT_DATE\tRIGHT_AMT\tRIGHT_REF\tNOTE")
+	for _, row := range t.rows {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.typ, row.leftID, row.leftDt, row.leftAmt, row.leftRef,
+			row.rightID, row.rightDt, row.rightAmt, row.rightRef, row.note)
+	}
+	return tw.Flush()
+}

--- a/engine/index.go
+++ b/engine/index.go
@@ -1,0 +1,123 @@
+package engine
+
+import "time"
+
+// bucket holds a right-side transaction in a compact, pointer-lean form.
+//
+// Date is stored as Unix nanoseconds (int64) rather than time.Time, eliminating
+// the time.Time.loc (*Location) pointer from every bucket. At 20M entries that
+// removes 20M pointer fields from the GC scan graph per collection cycle.
+//
+// Reference is NOT stored here — it is available as the map key in
+// memoryIndex.data and is injected by toTransaction(ref) at retrieval time.
+// This eliminates a second duplicate string pointer per bucket.
+//
+// Pointer fields retained: id, currency, name, source (4 strings).
+// Pointer fields eliminated vs. previous design: tx.Date.loc, tx.Reference (2 pointers).
+type bucket struct {
+	id       string
+	dateUnix int64 // tx.Date.UnixNano() — no *Location pointer
+	amount   int64
+	currency string
+	name     string
+	source   string
+	used     bool
+}
+
+// toTransaction reconstructs a full Transaction from a bucket for output events.
+// ref must be the map key under which this bucket is stored.
+func (b *bucket) toTransaction(ref string) Transaction {
+	return Transaction{
+		ID:        b.id,
+		Date:      time.Unix(0, b.dateUnix).UTC(),
+		Amount:    b.amount,
+		Currency:  b.currency,
+		Reference: ref,
+		Name:      b.name,
+		Source:    b.source,
+	}
+}
+
+// RightIndex is the right-side lookup store for ReconcileStreaming.
+//
+// Not thread-safe. Single-threaded use only.
+// Close() must be called when the index is no longer needed.
+//
+// The default in-memory implementation (NewMemoryIndex) requires the right side
+// to fit in RAM. For datasets where the right side exceeds available memory, a
+// disk-backed implementation of this interface can be substituted.
+// ReconcileStreaming accepts any RightIndex without modification — it is the
+// only coupling point between the reconciler and the storage backend.
+type RightIndex interface {
+	// Add inserts a transaction into the index.
+	// Implementations strip Raw and convert Date to a pointer-free representation
+	// before storage. Callers should not assume Raw or Date are preserved as-is.
+	Add(tx Transaction) error
+
+	// Get returns all buckets matching the given reference key.
+	// Callers may set bucket.used = true to mark a bucket as consumed.
+	Get(ref string) []*bucket
+
+	// IterateUnused calls fn for every transaction not marked as used.
+	// Iteration order is unspecified.
+	IterateUnused(fn func(tx Transaction) error) error
+
+	// Close releases any resources held by the index (file handles, temp files, etc.).
+	Close() error
+}
+
+// memoryIndex is the default in-memory RightIndex implementation.
+//
+// Memory: each bucket stores 4 strings + 2 int64s + 1 bool. Reference and Raw
+// are not stored per-bucket (Reference is the map key; Raw is stripped at Add).
+// Date is stored as int64 Unix nanos — no *Location pointer.
+// At 20M right-side rows, expect 4–6 GB depending on average string lengths.
+//
+// Documented limit: if the right side does not fit in RAM, implement RightIndex
+// backed by SQLite, mmap, or another disk store and pass it to ReconcileStreaming.
+type memoryIndex struct {
+	data map[string][]*bucket
+}
+
+// NewMemoryIndex returns a new empty in-memory RightIndex.
+func NewMemoryIndex() RightIndex {
+	return &memoryIndex{
+		data: make(map[string][]*bucket),
+	}
+}
+
+func (m *memoryIndex) Add(tx Transaction) error {
+	// Store compact bucket — no Raw, no time.Time, no duplicate Reference.
+	b := &bucket{
+		id:       tx.ID,
+		dateUnix: tx.Date.UnixNano(),
+		amount:   tx.Amount,
+		currency: tx.Currency,
+		name:     tx.Name,
+		source:   tx.Source,
+	}
+	m.data[tx.Reference] = append(m.data[tx.Reference], b)
+	return nil
+}
+
+func (m *memoryIndex) Get(ref string) []*bucket {
+	return m.data[ref]
+}
+
+func (m *memoryIndex) IterateUnused(fn func(tx Transaction) error) error {
+	for ref, buckets := range m.data {
+		for _, b := range buckets {
+			if !b.used {
+				if err := fn(b.toTransaction(ref)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *memoryIndex) Close() error {
+	m.data = nil
+	return nil
+}

--- a/engine/parser.go
+++ b/engine/parser.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"bufio"
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -13,21 +15,37 @@ import (
 	"github.com/reconify/reconify/config"
 )
 
-// ParseCSV reads a CSV file and returns normalized transactions according to the source config.
-func ParseCSV(sourceName string, filePath string, cfg config.CSVParserCfg) ([]Transaction, error) {
+// ParseCSVEach streams a CSV file, calling fn for each parsed transaction.
+//
+// Ownership: each call receives a distinct Transaction by value. The callback
+// owns the value and may retain it without copying. No struct is reused between calls.
+//
+// Error format: all errors include filePath, row number (1-based), the original
+// field value, and the source name. Example:
+//
+//	bank.csv: row 452133: source "bank": invalid date "2023-99-01" with layout "2006-01-02"
+//
+// Context: checked between rows. Returns ctx.Err() on cancellation.
+func ParseCSVEach(
+	ctx context.Context,
+	sourceName string,
+	filePath string,
+	cfg config.CSVParserCfg,
+	fn func(tx Transaction, rowNum int) error,
+) error {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("open %q: %w", filePath, err)
+		return fmt.Errorf("open %q: %w", filePath, err)
 	}
 	defer f.Close()
 
-	r := csv.NewReader(f)
+	r := csv.NewReader(bufio.NewReaderSize(f, 1<<20))
 	r.TrimLeadingSpace = true
 
 	// Read header row
 	headers, err := r.Read()
 	if err != nil {
-		return nil, fmt.Errorf("read header: %w", err)
+		return fmt.Errorf("%s: read header: %w", filePath, err)
 	}
 	colIndex := buildColIndex(headers)
 
@@ -39,7 +57,7 @@ func ParseCSV(sourceName string, filePath string, cfg config.CSVParserCfg) ([]Tr
 		}
 	}
 
-	// Resolve decimal and thousands separators
+	// Resolve decimal separator
 	decimal := "."
 	if cfg.Decimal != "" {
 		decimal = cfg.Decimal
@@ -50,44 +68,85 @@ func ParseCSV(sourceName string, filePath string, cfg config.CSVParserCfg) ([]Tr
 		multiplier = 1
 	}
 
-	var txns []Transaction
-	rowNum := 0
+	// Date cache: capped at 1000 unique keys, then permanently disabled.
+	// Eliminates repeated time.ParseInLocation calls for files with many same-date rows.
+	// Disabled automatically when timestamp columns are detected (per-row unique values
+	// fill the cache quickly and trigger permanent fallback to direct parsing).
+	dateCache := make(map[string]time.Time)
+	cacheEnabled := true
 
+	rowNum := 0
 	for {
+		// Check for context cancellation between rows
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		record, err := r.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read row %d: %w", rowNum+2, err)
+			return fmt.Errorf("%s: row %d: %w", filePath, rowNum+2, err)
 		}
 		rowNum++
 
-		raw := make(map[string]string, len(headers))
-		for i, h := range headers {
-			if i < len(record) {
-				raw[h] = record[i]
-			}
+		// Date
+		dateStr := strings.TrimSpace(getCol(record, colIndex, cfg.DateCol))
+		if dateStr == "" {
+			return fmt.Errorf("%s: row %d: source %q: date column %q is empty",
+				filePath, rowNum+1, sourceName, cfg.DateCol)
 		}
 
-		// Date
-		dateStr := getCol(record, colIndex, cfg.DateCol)
-		if dateStr == "" {
-			return nil, fmt.Errorf("row %d: date column %q is empty", rowNum+1, cfg.DateCol)
-		}
-		date, err := time.ParseInLocation(cfg.DateLayout, strings.TrimSpace(dateStr), loc)
-		if err != nil {
-			return nil, fmt.Errorf("row %d: parse date %q with layout %q: %w", rowNum+1, dateStr, cfg.DateLayout, err)
+		var date time.Time
+		if cacheEnabled {
+			if t, ok := dateCache[dateStr]; ok {
+				date = t
+			} else {
+				t, parseErr := time.ParseInLocation(cfg.DateLayout, dateStr, loc)
+				if parseErr != nil {
+					return fmt.Errorf("%s: row %d: source %q: invalid date %q with layout %q: %w",
+						filePath, rowNum+1, sourceName, dateStr, cfg.DateLayout, parseErr)
+				}
+				date = t
+				if len(dateCache) >= 1000 {
+					// Permanently disable cache and free memory.
+					cacheEnabled = false
+					dateCache = nil
+				} else {
+					dateCache[dateStr] = t
+				}
+			}
+		} else {
+			t, parseErr := time.ParseInLocation(cfg.DateLayout, dateStr, loc)
+			if parseErr != nil {
+				return fmt.Errorf("%s: row %d: source %q: invalid date %q with layout %q: %w",
+					filePath, rowNum+1, sourceName, dateStr, cfg.DateLayout, parseErr)
+			}
+			date = t
 		}
 
 		// Amount
 		amtStr := getCol(record, colIndex, cfg.AmountCol)
 		if amtStr == "" {
-			return nil, fmt.Errorf("row %d: amount column %q is empty", rowNum+1, cfg.AmountCol)
+			return fmt.Errorf("%s: row %d: source %q: amount column %q is empty",
+				filePath, rowNum+1, sourceName, cfg.AmountCol)
 		}
 		amount, err := parseAmount(amtStr, decimal, cfg.Thousands, multiplier)
 		if err != nil {
-			return nil, fmt.Errorf("row %d: parse amount %q: %w", rowNum+1, amtStr, err)
+			return fmt.Errorf("%s: row %d: source %q: parse amount %q: %w",
+				filePath, rowNum+1, sourceName, amtStr, err)
+		}
+
+		// Raw map — only allocated when SkipRaw is false
+		var raw map[string]string
+		if !cfg.SkipRaw {
+			raw = make(map[string]string, len(headers))
+			for i, h := range headers {
+				if i < len(record) {
+					raw[h] = record[i]
+				}
+			}
 		}
 
 		txn := Transaction{
@@ -101,10 +160,23 @@ func ParseCSV(sourceName string, filePath string, cfg config.CSVParserCfg) ([]Tr
 			Name:      strings.TrimSpace(getCol(record, colIndex, cfg.NameCol)),
 		}
 
-		txns = append(txns, txn)
+		if err := fn(txn, rowNum); err != nil {
+			return err
+		}
 	}
 
-	return txns, nil
+	return nil
+}
+
+// ParseCSV reads a CSV file and returns normalized transactions according to the source config.
+// It is a convenience wrapper around ParseCSVEach for callers that need a complete slice.
+func ParseCSV(sourceName string, filePath string, cfg config.CSVParserCfg) ([]Transaction, error) {
+	var txns []Transaction
+	err := ParseCSVEach(context.Background(), sourceName, filePath, cfg, func(tx Transaction, _ int) error {
+		txns = append(txns, tx)
+		return nil
+	})
+	return txns, err
 }
 
 // buildColIndex builds a case-insensitive column name → index map.

--- a/engine/parser_bench_test.go
+++ b/engine/parser_bench_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/reconify/reconify/config"
+)
+
+// writeSyntheticCSV writes n rows to a temp file and returns the path.
+// Dates repeat on a 365-day cycle to simulate real financial files.
+// References are unique per row.
+func writeSyntheticCSV(tb testing.TB, rows int) string {
+	tb.Helper()
+	f, err := os.CreateTemp(tb.TempDir(), "bench_*.csv")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	fmt.Fprintln(f, "date,amount,currency,reference,name")
+	dates := [...]string{
+		"2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05",
+		"2024-02-01", "2024-02-02", "2024-02-03", "2024-02-04", "2024-02-05",
+	}
+	for i := 0; i < rows; i++ {
+		fmt.Fprintf(f, "%s,%d.%02d,USD,REF%010d,Merchant %d\n",
+			dates[i%len(dates)], 100+i%10000, i%100, i, i%500)
+	}
+	return f.Name()
+}
+
+func benchmarkParseCSVEach(b *testing.B, rows int, skipRaw bool) {
+	path := writeSyntheticCSV(b, rows)
+	cfg := config.CSVParserCfg{
+		Type:       "csv",
+		DateCol:    "date",
+		DateLayout: "2006-01-02",
+		AmountCol:  "amount",
+		Multiplier: 100,
+		CurrencyCol: "currency",
+		RefCol:     "reference",
+		NameCol:    "name",
+		SkipRaw:    skipRaw,
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		count := 0
+		if err := ParseCSVEach(context.Background(), "bench", path, cfg, func(_ Transaction, _ int) error {
+			count++
+			return nil
+		}); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportMetric(float64(count), "rows/op")
+	}
+}
+
+func BenchmarkParseCSVEach_100k(b *testing.B)         { benchmarkParseCSVEach(b, 100_000, false) }
+func BenchmarkParseCSVEach_1M(b *testing.B)           { benchmarkParseCSVEach(b, 1_000_000, false) }
+func BenchmarkParseCSVEach_1M_SkipRaw(b *testing.B)   { benchmarkParseCSVEach(b, 1_000_000, true) }
+
+// TestMemoryIndex_PerRowFootprint measures the actual heap bytes consumed per
+// indexed row. This replaces estimation with measurement.
+// Run with: go test -run TestMemoryIndex_PerRowFootprint -v ./engine/...
+func TestMemoryIndex_PerRowFootprint(t *testing.T) {
+	const rows = 1_000_000
+
+	path := writeSyntheticCSV(t, rows)
+	cfg := config.CSVParserCfg{
+		Type:       "csv",
+		DateCol:    "date",
+		DateLayout: "2006-01-02",
+		AmountCol:  "amount",
+		Multiplier: 100,
+		CurrencyCol: "currency",
+		RefCol:     "reference",
+		NameCol:    "name",
+		SkipRaw:    true,
+	}
+
+	idx := NewMemoryIndex()
+
+	// Force GC before measurement
+	runtime.GC()
+	var msBefore runtime.MemStats
+	runtime.ReadMemStats(&msBefore)
+
+	if err := ParseCSVEach(context.Background(), "bench", path, cfg, func(tx Transaction, _ int) error {
+		return idx.Add(tx)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime.GC()
+	var msAfter runtime.MemStats
+	runtime.ReadMemStats(&msAfter)
+
+	// TotalAlloc is monotonically increasing — unaffected by GC cycles.
+	// It measures total bytes allocated during the index build, approximating
+	// the per-row allocation cost (including short-lived temporaries).
+	allocDelta := int64(msAfter.TotalAlloc) - int64(msBefore.TotalAlloc)
+	perRow := allocDelta / rows
+
+	t.Logf("memoryIndex: %d rows, total alloc %d MB, ~%d bytes/row (includes GC'd temporaries)",
+		rows, allocDelta/1024/1024, perRow)
+
+	idx.Close()
+}

--- a/engine/reconciler.go
+++ b/engine/reconciler.go
@@ -1,8 +1,10 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -67,6 +69,381 @@ func Reconcile(pairName, leftSource, rightSource string, left, right []Transacti
 	}
 
 	return result, nil
+}
+
+// ReconcileStreaming is the canonical streaming reconciliation function.
+//
+// It accepts a RightIndex (created by the caller) and a ResultWriter, and emits
+// events incrementally as it processes both sides. ReconcileStreaming never
+// assumes a specific RightIndex implementation — passing newMemoryIndex() is the
+// default; a disk-backed index can be substituted without changing this function.
+//
+// Token mode ordering: reference matching always runs first. Token/name matching
+// applies only to transactions that remain unmatched after the reference pass.
+// Token matches cannot override reference matches.
+//
+// Memory complexity:
+//   - Right-side index: O(n_right) via the provided RightIndex
+//   - Right dup tracking: O(unique_refs_right) for counting + O(dup_right_txns) for groups
+//   - Left ref tracking: O(unique_refs_left) for counting + O(dup_left_txns) for groups
+//   - Token mode buffer: O(n_unmatched) worst case — guarded by maxTokenBuffer
+//
+// Empty references ("") are treated as unmatched and are never grouped as duplicates.
+func ReconcileStreaming(
+	ctx context.Context,
+	pairName string,
+	leftSource string,
+	rightSource string,
+	leftPath string,
+	rightPath string,
+	leftCfg config.CSVParserCfg,
+	rightCfg config.CSVParserCfg,
+	pair config.Pair,
+	idx RightIndex,
+	w ResultWriter,
+	maxTokenBuffer int,
+) error {
+	dateWindowDays, err := parseDateWindow(pair.DateWindow)
+	if err != nil {
+		return fmt.Errorf("invalid date_window: %w", err)
+	}
+
+	tolerance := pair.AmountToleranceMinor
+
+	// -----------------------------------------------------------------------
+	// Pass 1: stream right CSV into index, track right duplicates
+	// -----------------------------------------------------------------------
+	// Force SkipRaw for the right side — Raw data in the index wastes memory.
+	rightCfgNoRaw := rightCfg
+	rightCfgNoRaw.SkipRaw = true
+
+	// Lightweight right-side duplicate detection.
+	// rightSeen tracks occurrence count per reference, capped at 2 (saturating).
+	// rightDupRefs collects references that appeared ≥ 2 times; the full
+	// Transaction set is retrieved via a targeted re-scan after this pass.
+	rightSeen    := make(map[string]uint8)
+	rightDupRefs := make(map[string]bool)
+	var totalRight int
+
+	if err := ParseCSVEach(ctx, rightSource, rightPath, rightCfgNoRaw, func(tx Transaction, _ int) error {
+		totalRight++
+		if tx.Reference == "" {
+			return idx.Add(tx)
+		}
+		if rightSeen[tx.Reference] < 2 {
+			rightSeen[tx.Reference]++
+		}
+		if rightSeen[tx.Reference] == 2 {
+			rightDupRefs[tx.Reference] = true
+		}
+		return idx.Add(tx)
+	}); err != nil {
+		return fmt.Errorf("parse right source: %w", err)
+	}
+
+	// Emit right duplicate groups via targeted re-scan of the right file.
+	// collectDuplicates is only called when duplicates actually exist;
+	// for datasets with no duplicates this is a no-op.
+	if len(rightDupRefs) > 0 {
+		groups, err := collectDuplicates(ctx, rightSource, rightPath, rightCfg, rightDupRefs)
+		if err != nil {
+			return fmt.Errorf("collect right duplicates: %w", err)
+		}
+		for _, g := range groups {
+			if err := w.WriteDuplicate(g); err != nil {
+				return err
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Pass 2: stream left CSV, match against index, emit events immediately
+	// -----------------------------------------------------------------------
+	// Lightweight left-side duplicate detection — same saturating-uint8 approach
+	// as the right side. leftFirst/leftDups are replaced by a targeted re-scan
+	// after this pass (collectDuplicates), called only when duplicates exist.
+	leftSeen    := make(map[string]uint8)
+	leftDupRefs := make(map[string]bool)
+
+	var (
+		matchedCount       int
+		amountDiffCount    int
+		timingDiffCount    int
+		unmatchedLeftCount int
+		tokenUnmatchedLeft []Transaction
+	)
+	var totalLeft int
+
+	if err := ParseCSVEach(ctx, leftSource, leftPath, leftCfg, func(ltx Transaction, _ int) error {
+		totalLeft++
+
+		// Track left duplicates (count only; full transactions retrieved in third pass)
+		if ltx.Reference != "" {
+			if leftSeen[ltx.Reference] < 2 {
+				leftSeen[ltx.Reference]++
+			}
+			if leftSeen[ltx.Reference] == 2 {
+				leftDupRefs[ltx.Reference] = true
+			}
+		}
+
+		// Empty reference: classify as unmatched immediately
+		if ltx.Reference == "" {
+			unmatchedLeftCount++
+			if pair.NameMode == "tokens" {
+				tokenUnmatchedLeft = append(tokenUnmatchedLeft, ltx)
+				return nil
+			}
+			return w.WriteUnmatched(ltx, "left")
+		}
+
+		// Attempt reference matching.
+		// Cache left date as Unix nanos once per row — avoids recomputing
+		// it for every right-side bucket candidate.
+		buckets := idx.Get(ltx.Reference)
+		matched := false
+		ltxDateNano := ltx.Date.UnixNano()
+		for _, b := range buckets {
+			if b.used {
+				continue
+			}
+
+			amtDiff := ltx.Amount - b.amount
+			if amtDiff < 0 {
+				amtDiff = -amtDiff
+			}
+			daysDiff := daysBetweenNano(ltxDateNano, b.dateUnix)
+			amtOk := amtDiff <= tolerance
+			dateOk := dateWindowDays == 0 || daysDiff <= dateWindowDays
+
+			if amtOk && dateOk {
+				b.used = true
+				matched = true
+				matchedCount++
+				return w.WriteMatch(MatchedPair{Left: ltx, Right: b.toTransaction(ltx.Reference)})
+			}
+			if !amtOk && dateOk {
+				b.used = true
+				matched = true
+				amountDiffCount++
+				return w.WriteAmountDiff(AmountDiffPair{
+					Left:      ltx,
+					Right:     b.toTransaction(ltx.Reference),
+					DiffMinor: ltx.Amount - b.amount,
+				})
+			}
+			if amtOk && !dateOk {
+				b.used = true
+				matched = true
+				timingDiffCount++
+				return w.WriteTimingDiff(TimingDiffPair{
+					Left:     ltx,
+					Right:    b.toTransaction(ltx.Reference),
+					DaysDiff: daysDiff,
+				})
+			}
+		}
+
+		if !matched {
+			unmatchedLeftCount++
+			if pair.NameMode == "tokens" {
+				tokenUnmatchedLeft = append(tokenUnmatchedLeft, ltx)
+				return nil
+			}
+			return w.WriteUnmatched(ltx, "left")
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("parse left source: %w", err)
+	}
+
+	// Emit left duplicate groups via targeted re-scan of the left file.
+	if len(leftDupRefs) > 0 {
+		groups, err := collectDuplicates(ctx, leftSource, leftPath, leftCfg, leftDupRefs)
+		if err != nil {
+			return fmt.Errorf("collect left duplicates: %w", err)
+		}
+		for _, g := range groups {
+			if err := w.WriteDuplicate(g); err != nil {
+				return err
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// After pass 2: collect unused right-side transactions
+	// -----------------------------------------------------------------------
+	var tokenUnmatchedRight []Transaction
+	unmatchedRightCount := 0
+
+	if err := idx.IterateUnused(func(tx Transaction) error {
+		unmatchedRightCount++
+		if pair.NameMode == "tokens" {
+			tokenUnmatchedRight = append(tokenUnmatchedRight, tx)
+			return nil
+		}
+		return w.WriteUnmatched(tx, "right")
+	}); err != nil {
+		return err
+	}
+
+	// -----------------------------------------------------------------------
+	// Optional token-mode second pass on unmatched transactions
+	//
+	// Token mode is an edge case / fallback. It buffers unmatched transactions
+	// from both sides. Worst case (all unmatched): O(n_total) memory.
+	// Guarded by maxTokenBuffer advisory limit.
+	// -----------------------------------------------------------------------
+	if pair.NameMode == "tokens" {
+		bufTotal := len(tokenUnmatchedLeft) + len(tokenUnmatchedRight)
+		if maxTokenBuffer > 0 && bufTotal > maxTokenBuffer {
+			fmt.Fprintf(os.Stderr,
+				"warning: token mode unmatched buffer is %d rows (limit %d); memory usage may be high\n",
+				bufTotal, maxTokenBuffer)
+		}
+
+		// Run Jaccard secondary matching on the buffered unmatched transactions.
+		// Returns matched pairs plus the remaining (still unmatched) left/right slices.
+		tokenMatches, remainLeft, remainRight := matchByNameTokensStreaming(
+			tokenUnmatchedLeft, tokenUnmatchedRight, tolerance, dateWindowDays,
+		)
+		for _, mp := range tokenMatches {
+			matchedCount++
+			// Each token match reduces unmatched counts
+			unmatchedLeftCount--
+			unmatchedRightCount--
+			if err := w.WriteMatch(mp); err != nil {
+				return err
+			}
+		}
+		for _, tx := range remainLeft {
+			if err := w.WriteUnmatched(tx, "left"); err != nil {
+				return err
+			}
+		}
+		for _, tx := range remainRight {
+			if err := w.WriteUnmatched(tx, "right"); err != nil {
+				return err
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Summary
+	// -----------------------------------------------------------------------
+	dupCount := len(leftDupRefs) + len(rightDupRefs)
+	total := totalLeft
+	if totalRight > total {
+		total = totalRight
+	}
+	matchRate := 0.0
+	if total > 0 {
+		matchRate = math.Round(float64(matchedCount)/float64(total)*10000) / 100
+	}
+
+	if err := w.WriteSummary(Summary{
+		TotalLeft:       totalLeft,
+		TotalRight:      totalRight,
+		MatchedCount:    matchedCount,
+		UnmatchedLeft:   unmatchedLeftCount,
+		UnmatchedRight:  unmatchedRightCount,
+		AmountDiffCount: amountDiffCount,
+		TimingDiffCount: timingDiffCount,
+		DuplicateCount:  dupCount,
+		MatchRatePct:    matchRate,
+	}); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+// matchByNameTokensStreaming runs the Jaccard secondary pass on pre-buffered
+// unmatched slices and returns a slice of MatchedPairs plus the remaining
+// (still unmatched) slices in-place.
+func matchByNameTokensStreaming(
+	left, right []Transaction,
+	tolerance int64,
+	windowDays int,
+) (matches []MatchedPair, remainLeft, remainRight []Transaction) {
+	usedRight := make(map[string]bool)
+
+	for _, ltx := range left {
+		if ltx.Name == "" {
+			remainLeft = append(remainLeft, ltx)
+			continue
+		}
+		ltokens := tokenize(ltx.Name)
+		bestScore := 0.0
+		bestIdx := -1
+		for i, rtx := range right {
+			if usedRight[rtx.ID] || rtx.Name == "" {
+				continue
+			}
+			amtDiff := ltx.Amount - rtx.Amount
+			if amtDiff < 0 {
+				amtDiff = -amtDiff
+			}
+			if amtDiff > tolerance {
+				continue
+			}
+			if windowDays > 0 && daysBetween(ltx.Date, rtx.Date) > windowDays {
+				continue
+			}
+			score := tokenOverlap(ltokens, tokenize(rtx.Name))
+			if score > bestScore {
+				bestScore = score
+				bestIdx = i
+			}
+		}
+		if bestScore > 0.5 && bestIdx >= 0 {
+			matches = append(matches, MatchedPair{Left: ltx, Right: right[bestIdx]})
+			usedRight[right[bestIdx].ID] = true
+		} else {
+			remainLeft = append(remainLeft, ltx)
+		}
+	}
+	for _, rtx := range right {
+		if !usedRight[rtx.ID] {
+			remainRight = append(remainRight, rtx)
+		}
+	}
+	return matches, remainLeft, remainRight
+}
+
+// collectDuplicates re-scans a CSV file and returns a DuplicateGroup for every
+// reference in dupRefs. It is invoked only when duplicates were detected during
+// the primary pass; for datasets with no duplicates this function is never called.
+//
+// Using the original cfg (not rightCfgNoRaw) preserves the Raw field if the
+// caller has configured SkipRaw = false.
+//
+// Memory: O(n_dup_rows) — only rows whose reference is in dupRefs are retained.
+func collectDuplicates(
+	ctx        context.Context,
+	sourceName string,
+	path       string,
+	cfg        config.CSVParserCfg,
+	dupRefs    map[string]bool,
+) ([]DuplicateGroup, error) {
+	byRef := make(map[string][]Transaction, len(dupRefs))
+	if err := ParseCSVEach(ctx, sourceName, path, cfg, func(tx Transaction, _ int) error {
+		if dupRefs[tx.Reference] {
+			byRef[tx.Reference] = append(byRef[tx.Reference], tx)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	groups := make([]DuplicateGroup, 0, len(byRef))
+	for ref, txns := range byRef {
+		groups = append(groups, DuplicateGroup{
+			Source:       sourceName,
+			Reference:    ref,
+			Transactions: txns,
+		})
+	}
+	return groups, nil
 }
 
 // matchByReference matches transactions by reference string.
@@ -287,6 +664,18 @@ func daysBetween(a, b time.Time) int {
 		diff = -diff
 	}
 	return int(diff.Hours() / 24)
+}
+
+// daysBetweenNano returns the absolute number of days between two Unix nanosecond
+// timestamps. Used in ReconcileStreaming where the right-side date is stored as
+// int64 in the bucket, avoiding time.Time reconstruction for comparison.
+func daysBetweenNano(aNano, bNano int64) int {
+	const nsPerDay = 24 * 60 * 60 * int64(1e9)
+	diff := aNano - bNano
+	if diff < 0 {
+		diff = -diff
+	}
+	return int(diff / nsPerDay)
 }
 
 // tokenize splits a string into lower-case word tokens.

--- a/engine/reconciler_bench_test.go
+++ b/engine/reconciler_bench_test.go
@@ -1,0 +1,208 @@
+package engine
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/reconify/reconify/config"
+)
+
+// benchmarkReconcileStreaming creates two synthetic CSV files (left and right)
+// and benchmarks ReconcileStreaming end-to-end with ndjson (O(1)) output.
+// Both sides are identical (100% reference match rate) — this is the
+// best-case scenario measuring pure CPU + hash throughput with warm OS cache.
+// For a realistic mixed-rate benchmark see BenchmarkReconcileStreaming_20M_Realistic.
+func benchmarkReconcileStreaming(b *testing.B, rows int) {
+	leftPath  := writeSyntheticCSV(b, rows)
+	rightPath := writeSyntheticCSV(b, rows)
+
+	cfg := config.CSVParserCfg{
+		Type:        "csv",
+		DateCol:     "date",
+		DateLayout:  "2006-01-02",
+		AmountCol:   "amount",
+		Multiplier:  100,
+		CurrencyCol: "currency",
+		RefCol:      "reference",
+		NameCol:     "name",
+		SkipRaw:     true,
+	}
+
+	pair := config.Pair{
+		Left:                 "left",
+		Right:                "right",
+		AmountToleranceMinor: 0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		idx := NewMemoryIndex()
+		w, _ := NewResultWriter("ndjson", io.Discard)
+
+		if err := ReconcileStreaming(
+			context.Background(),
+			"bench_pair",
+			"left", "right",
+			leftPath, rightPath,
+			cfg, cfg,
+			pair,
+			idx, w,
+			100_000,
+		); err != nil {
+			b.Fatal(err)
+		}
+		idx.Close()
+		b.ReportMetric(float64(rows), "rows/op")
+	}
+}
+
+func BenchmarkReconcileStreaming_100k(b *testing.B) { benchmarkReconcileStreaming(b, 100_000) }
+func BenchmarkReconcileStreaming_1M(b *testing.B)   { benchmarkReconcileStreaming(b, 1_000_000) }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Large-file benchmarks (require pre-generated fixture data)
+//
+// These benchmarks use the 20M-row CSV files produced by gen_bench_data.go.
+// They are skipped automatically when BENCH_DATA_DIR is not set, so they
+// never block normal `go test ./...` runs.
+//
+// Generate data once, then run:
+//
+//	go run scripts/gen_bench_data.go --rows 20000000 --out /tmp/bench-data
+//	BENCH_DATA_DIR=/tmp/bench-data go test -run='^$' \
+//	  -bench='BenchmarkReconcileStreaming_20M|BenchmarkParseCSVEach_20M' \
+//	  -benchtime=1x -benchmem -timeout=600s ./engine/...
+//
+// Use -benchtime=1x because a single 20M-row reconciliation takes ~60–120 s;
+// the benchmark framework's auto-calibration would run it many times otherwise.
+//
+// What the fixtures measure (vs. the synthetic benchmarks above):
+//   - Different column names on left vs right (exercises field mapping)
+//   - Mixed outcome distribution: 85% matched, 5% amount diff, 5% timing diff,
+//     5% unmatched left, 5% unmatched right  (vs 100% match above)
+//   - File size ~1.2 GB per side — likely exceeds L3 cache, so OS I/O is real
+// ─────────────────────────────────────────────────────────────────────────────
+
+// largeFileCfgs returns the CSVParserCfg for left.csv and right.csv as generated
+// by scripts/gen_bench_data.go. Column names differ between the two files.
+func largeFileCfgs() (left, right config.CSVParserCfg) {
+	left = config.CSVParserCfg{
+		Type:        "csv",
+		DateCol:     "date",
+		DateLayout:  "2006-01-02",
+		AmountCol:   "amount",
+		Multiplier:  1,
+		CurrencyCol: "currency",
+		RefCol:      "ref_id",
+		NameCol:     "description",
+		SkipRaw:     true,
+	}
+	right = config.CSVParserCfg{
+		Type:        "csv",
+		DateCol:     "txn_date",
+		DateLayout:  "2006-01-02",
+		AmountCol:   "txn_amount",
+		Multiplier:  1,
+		CurrencyCol: "txn_currency",
+		RefCol:      "txn_ref",
+		NameCol:     "merchant",
+		SkipRaw:     true,
+	}
+	return left, right
+}
+
+// requireBenchData returns the path to left.csv and right.csv from BENCH_DATA_DIR,
+// or skips the benchmark with an actionable message if the env var is unset.
+func requireBenchData(b *testing.B) (leftPath, rightPath string) {
+	b.Helper()
+	dataDir := os.Getenv("BENCH_DATA_DIR")
+	if dataDir == "" {
+		b.Skip("BENCH_DATA_DIR not set — generate data first:\n" +
+			"  go run scripts/gen_bench_data.go --rows 20000000 --out /tmp/bench-data\n" +
+			"  export BENCH_DATA_DIR=/tmp/bench-data")
+	}
+	leftPath  = filepath.Join(dataDir, "left.csv")
+	rightPath = filepath.Join(dataDir, "right.csv")
+	for _, p := range []string{leftPath, rightPath} {
+		if _, err := os.Stat(p); err != nil {
+			b.Skipf("file not found: %s (re-run gen_bench_data.go)", p)
+		}
+	}
+	return leftPath, rightPath
+}
+
+// BenchmarkParseCSVEach_20M_Left measures streaming parse throughput on a real
+// 20M-row CSV file with the bank/ledger column schema.
+// Baseline: ~1.5–2.0 M rows/sec on NVMe with warm OS cache.
+func BenchmarkParseCSVEach_20M_Left(b *testing.B) {
+	leftPath, _ := requireBenchData(b)
+	leftCfg, _  := largeFileCfgs()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		count := 0
+		if err := ParseCSVEach(context.Background(), "bank", leftPath, leftCfg,
+			func(_ Transaction, _ int) error {
+				count++
+				return nil
+			},
+		); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportMetric(float64(count), "rows/op")
+	}
+}
+
+// BenchmarkReconcileStreaming_20M_Realistic measures end-to-end reconciliation
+// of two 20M-row CSV files with a realistic mixed outcome distribution:
+//   - 85% perfect matches (same ref, amount, date)
+//   - 5%  amount diffs   (right amount +1–50 minor units)
+//   - 5%  timing diffs   (right date +1–3 days)
+//   - 5%  unmatched left
+//   - 5%  unmatched right
+//
+// The two files use different column schemas to exercise CSVParserCfg mapping.
+// Output is written to io.Discard (ndjson) so writer overhead is minimal.
+//
+// Run with -benchtime=1x; a single iteration takes ~60–120 s.
+// Peak RSS: the right-side memoryIndex holds ~20M rows × ~200 bytes ≈ 4 GB.
+func BenchmarkReconcileStreaming_20M_Realistic(b *testing.B) {
+	leftPath, rightPath := requireBenchData(b)
+	leftCfg, rightCfg  := largeFileCfgs()
+
+	pair := config.Pair{
+		Left:                 "bank",
+		Right:                "processor",
+		AmountToleranceMinor: 0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		idx := NewMemoryIndex()
+		w, _ := NewResultWriter("ndjson", io.Discard)
+
+		if err := ReconcileStreaming(
+			context.Background(),
+			"bench_20m",
+			"bank", "processor",
+			leftPath, rightPath,
+			leftCfg, rightCfg,
+			pair,
+			idx, w,
+			0,
+		); err != nil {
+			b.Fatal(err)
+		}
+		idx.Close()
+		b.ReportMetric(20_000_000, "rows/op")
+	}
+}

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"text/tabwriter"
+	"time"
 
 	"github.com/reconify/reconify/config"
 	"github.com/reconify/reconify/engine"
@@ -14,13 +19,19 @@ import (
 func newParseCmd() *cobra.Command {
 	var sourceName string
 	var filePath string
+	var format string
 
 	cmd := &cobra.Command{
 		Use:   "parse",
 		Short: "Parse a CSV file according to source configuration",
 		Long: `Parse a CSV file using a configured source parser.
-This is useful for testing and debugging parser configurations.
-Outputs one JSON transaction per line (NDJSON) to stdout.`,
+Streams parsed transactions to stdout in the requested format.
+
+Formats:
+  ndjson  (default) One JSON transaction per line; streaming, O(1) memory
+  csv               CSV rows; streaming, O(1) memory
+  table             Aligned ASCII table; buffers all rows in memory
+  json              JSON array; loads all transactions before writing`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = args
 			if sourceName == "" {
@@ -55,27 +66,113 @@ Outputs one JSON transaction per line (NDJSON) to stdout.`,
 				resolvedPath = matches[0]
 			}
 
-			txns, err := engine.ParseCSV(sourceName, resolvedPath, source.Parser)
-			if err != nil {
-				return fmt.Errorf("parse failed: %w", err)
+			switch format {
+			case "json":
+				return parseJSON(sourceName, resolvedPath, source.Parser, cmd)
+			case "ndjson":
+				return parseNDJSON(sourceName, resolvedPath, source.Parser, cmd)
+			case "csv":
+				return parseCSVOut(sourceName, resolvedPath, source.Parser, cmd)
+			case "table":
+				return parseTable(sourceName, resolvedPath, source.Parser, cmd)
+			default:
+				return fmt.Errorf("unknown format %q (valid: ndjson, csv, table, json)", format)
 			}
-
-			enc := json.NewEncoder(os.Stdout)
-			for _, tx := range txns {
-				if encErr := enc.Encode(tx); encErr != nil {
-					return fmt.Errorf("encode: %w", encErr)
-				}
-			}
-
-			cmd.PrintErrf("Parsed %d transactions from %q\n", len(txns), resolvedPath)
-			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&sourceName, "source", "", "Source name to use for parsing (required)")
 	cmd.Flags().StringVar(&filePath, "file", "", "CSV file path to parse (required)")
+	cmd.Flags().StringVar(&format, "format", "ndjson", `Output format: ndjson (default), csv, table, json`)
 
 	return cmd
+}
+
+// parseNDJSON streams transactions as NDJSON (one JSON object per line).
+func parseNDJSON(sourceName, filePath string, parserCfg config.CSVParserCfg, cmd *cobra.Command) error {
+	enc := json.NewEncoder(os.Stdout)
+	count := 0
+	err := engine.ParseCSVEach(context.Background(), sourceName, filePath, parserCfg, func(tx engine.Transaction, _ int) error {
+		count++
+		return enc.Encode(tx)
+	})
+	if err != nil {
+		return fmt.Errorf("parse failed: %w", err)
+	}
+	cmd.PrintErrf("Parsed %d transactions from %q\n", count, filePath)
+	return nil
+}
+
+// parseJSON loads all transactions and writes a JSON array.
+func parseJSON(sourceName, filePath string, parserCfg config.CSVParserCfg, cmd *cobra.Command) error {
+	txns, err := engine.ParseCSV(sourceName, filePath, parserCfg)
+	if err != nil {
+		return fmt.Errorf("parse failed: %w", err)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(txns); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+	cmd.PrintErrf("Parsed %d transactions from %q\n", len(txns), filePath)
+	return nil
+}
+
+var txCSVHeader = []string{"id", "date", "amount_minor", "currency", "reference", "name", "source"}
+
+// parseCSVOut streams transactions as CSV rows.
+func parseCSVOut(sourceName, filePath string, parserCfg config.CSVParserCfg, cmd *cobra.Command) error {
+	w := csv.NewWriter(os.Stdout)
+	if err := w.Write(txCSVHeader); err != nil {
+		return err
+	}
+	count := 0
+	err := engine.ParseCSVEach(context.Background(), sourceName, filePath, parserCfg, func(tx engine.Transaction, _ int) error {
+		count++
+		return w.Write([]string{
+			tx.ID,
+			tx.Date.Format(time.RFC3339),
+			strconv.FormatInt(tx.Amount, 10),
+			tx.Currency,
+			tx.Reference,
+			tx.Name,
+			tx.Source,
+		})
+	})
+	w.Flush()
+	if err != nil {
+		return fmt.Errorf("parse failed: %w", err)
+	}
+	if flushErr := w.Error(); flushErr != nil {
+		return flushErr
+	}
+	cmd.PrintErrf("Parsed %d transactions from %q\n", count, filePath)
+	return nil
+}
+
+// parseTable buffers all transactions and renders an ASCII table.
+func parseTable(sourceName, filePath string, parserCfg config.CSVParserCfg, cmd *cobra.Command) error {
+	var txns []engine.Transaction
+	err := engine.ParseCSVEach(context.Background(), sourceName, filePath, parserCfg, func(tx engine.Transaction, _ int) error {
+		txns = append(txns, tx)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("parse failed: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tDATE\tAMOUNT\tCURRENCY\tREFERENCE\tNAME\tSOURCE")
+	for _, tx := range txns {
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+			tx.ID, tx.Date.Format("2006-01-02"), tx.Amount,
+			tx.Currency, tx.Reference, tx.Name, tx.Source)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	cmd.PrintErrf("Parsed %d transactions from %q\n", len(txns), filePath)
+	return nil
 }
 
 func sourceNames(sources map[string]config.Source) []string {

--- a/internal/cli/reconcile.go
+++ b/internal/cli/reconcile.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,13 +16,25 @@ func newReconcileCmd() *cobra.Command {
 	var outputPath string
 	var leftFile string
 	var rightFile string
+	var format string
+	var maxTokenBuffer int
 
 	cmd := &cobra.Command{
 		Use:   "reconcile",
 		Short: "Run a reconciliation between two sources",
 		Long: `Execute a reconciliation between two configured sources.
-This command reads CSV files, normalizes them, and matches transactions
-according to the configured rules. Outputs JSON to stdout or a file.`,
+Reads CSV files, normalizes them, and matches transactions according to
+configured rules. Outputs results in the requested format.
+
+Formats:
+  json         (default) Indented JSON object; buffers full result in memory.
+               For files >500k rows, prefer json-stream, ndjson, or csv.
+  json-stream  Streaming JSON object; same structure as json but encodes
+               each event immediately. Lower GC pressure for large files.
+               Note: output is invalid JSON if the process is interrupted.
+  ndjson       One tagged JSON line per event; O(1) memory; crash-safe.
+  csv          Fixed-schema CSV; O(1) memory.
+  table        Aligned ASCII table; buffers all rows in memory.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = args
 			if pairName == "" {
@@ -62,23 +74,7 @@ according to the configured rules. Outputs JSON to stdout or a file.`,
 				return fmt.Errorf("right source: %w", err)
 			}
 
-			// Parse both sources
-			leftTxns, err := engine.ParseCSV(pair.Left, leftPath, leftSrc.Parser)
-			if err != nil {
-				return fmt.Errorf("parse left source: %w", err)
-			}
-			rightTxns, err := engine.ParseCSV(pair.Right, rightPath, rightSrc.Parser)
-			if err != nil {
-				return fmt.Errorf("parse right source: %w", err)
-			}
-
-			// Run reconciliation
-			result, err := engine.Reconcile(pairName, pair.Left, pair.Right, leftTxns, rightTxns, pair)
-			if err != nil {
-				return fmt.Errorf("reconciliation failed: %w", err)
-			}
-
-			// Write output
+			// Open output destination
 			var out *os.File
 			if outputPath == "-" || outputPath == "" {
 				out = os.Stdout
@@ -90,19 +86,53 @@ according to the configured rules. Outputs JSON to stdout or a file.`,
 				defer out.Close()
 			}
 
-			enc := json.NewEncoder(out)
-			enc.SetIndent("", "  ")
-			if err := enc.Encode(result); err != nil {
-				return fmt.Errorf("encode result: %w", err)
+			// All formats route through ReconcileStreaming.
+			// The caller creates the index and passes it in — ReconcileStreaming
+			// never assumes a specific RightIndex implementation.
+			w, err := engine.NewResultWriter(format, out)
+			if err != nil {
+				return err
 			}
 
-			cmd.PrintErrf(
-				"Reconciled %q: %d matched, %d unmatched (%.1f%% match rate)\n",
+			// Propagate pair metadata to json-stream writer so it can include
+			// pair/source names in the output object.
+			if jsw, ok := w.(interface {
+				SetMeta(pairName, leftSource, rightSource string)
+			}); ok {
+				jsw.SetMeta(pairName, pair.Left, pair.Right)
+			}
+
+			// For the default json writer, also set metadata fields via the
+			// jsonWriter's result struct. We do this by setting it on the result
+			// directly through the GetResult method if available.
+			if jw, ok := w.(interface {
+				GetResult() *engine.Result
+			}); ok {
+				r := jw.GetResult()
+				r.PairName = pairName
+				r.LeftSource = pair.Left
+				r.RightSource = pair.Right
+			}
+
+			idx := engine.NewMemoryIndex()
+			defer idx.Close()
+
+			if err := engine.ReconcileStreaming(
+				context.Background(),
 				pairName,
-				result.Summary.MatchedCount,
-				result.Summary.UnmatchedLeft+result.Summary.UnmatchedRight,
-				result.Summary.MatchRatePct,
-			)
+				pair.Left,
+				pair.Right,
+				leftPath,
+				rightPath,
+				leftSrc.Parser,
+				rightSrc.Parser,
+				pair,
+				idx,
+				w,
+				maxTokenBuffer,
+			); err != nil {
+				return fmt.Errorf("reconciliation failed: %w", err)
+			}
 
 			return nil
 		},
@@ -112,6 +142,10 @@ according to the configured rules. Outputs JSON to stdout or a file.`,
 	cmd.Flags().StringVarP(&outputPath, "out", "o", "-", "Output file path (use '-' for stdout)")
 	cmd.Flags().StringVar(&leftFile, "left-file", "", "Explicit path to left source CSV file")
 	cmd.Flags().StringVar(&rightFile, "right-file", "", "Explicit path to right source CSV file")
+	cmd.Flags().StringVar(&format, "format", "json",
+		`Output format: json (default), json-stream, ndjson, csv, table`)
+	cmd.Flags().IntVar(&maxTokenBuffer, "max-token-buffer", 100_000,
+		"Advisory row limit for token-mode unmatched buffer (0 = unlimited)")
 
 	return cmd
 }

--- a/scripts/bench_full.sh
+++ b/scripts/bench_full.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# bench_full.sh — production benchmark suite for the reconify streaming engine.
+#
+# Usage:
+#   ./scripts/bench_full.sh [flags]
+#
+# Flags:
+#   --rows N         Rows per file for data generation (default: 20000000)
+#   --data-dir DIR   Pre-generated data directory (default: /tmp/bench-data)
+#   --cold           Attempt OS page cache drop before RSS run
+#                    macOS: requires `sudo purge`
+#                    Linux: requires write access to /proc/sys/vm/drop_caches
+#   --skip-gen       Skip data generation even if files are absent (fail fast)
+#   --rss-only       Skip Go test benchmarks; only measure peak RSS + GC
+#
+# What this script measures:
+#
+#   1. Warm-cache throughput  (go test -bench, O(n) allocations measured)
+#      Runs BenchmarkParseCSVEach and BenchmarkReconcileStreaming against the
+#      large pre-generated files. Files will be in the OS page cache from the
+#      previous read, so this measures CPU-bound parse + hash throughput.
+#
+#   2. Peak RSS + GC churn  (single binary run with /usr/bin/time + GODEBUG)
+#      Runs `reconify reconcile` on 20M×20M rows with --format=ndjson (O(1)
+#      output). Captures peak RSS and GC cycle count.
+#      If --cold is passed, the page cache is dropped first so the first pass
+#      through both CSV files causes cold page faults, reflecting true I/O cost.
+#
+# Expected results (Apple M1 Pro / NVMe, 20M rows):
+#   Parse throughput:        ~1.5–2.0 M rows/sec (warm cache)
+#   Reconcile throughput:    ~250–400 k rows/sec (warm cache)
+#   Peak RSS (right index):  ~10–12 GB (right side held in memoryIndex)
+#   GC cycles:               <20 for ndjson output format
+#
+# Requirements:
+#   - Go ≥ 1.24 on PATH
+#   - No Python required; data generator is pure Go
+
+set -euo pipefail
+
+ROWS=20000000
+DATA_DIR="/tmp/bench-data"
+COLD_CACHE=false
+SKIP_GEN=false
+RSS_ONLY=false
+BINARY="/tmp/reconify-bench-full"
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rows)      ROWS="$2";     shift 2 ;;
+    --data-dir)  DATA_DIR="$2"; shift 2 ;;
+    --cold)      COLD_CACHE=true; shift ;;
+    --skip-gen)  SKIP_GEN=true; shift ;;
+    --rss-only)  RSS_ONLY=true; shift ;;
+    *) echo "unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLATFORM="$(uname -s)"
+LEFT_CSV="${DATA_DIR}/left.csv"
+RIGHT_CSV="${DATA_DIR}/right.csv"
+CONFIG_YAML="${DATA_DIR}/reconify.yaml"
+GC_LOG="${DATA_DIR}/gctrace.txt"
+
+header() {
+  echo ""
+  echo "════════════════════════════════════════════════════════════"
+  echo " $*"
+  echo "════════════════════════════════════════════════════════════"
+}
+
+header "reconify bench_full  rows=${ROWS}  platform=${PLATFORM}"
+echo "  data dir:  ${DATA_DIR}"
+echo "  cold:      ${COLD_CACHE}"
+echo "  rss-only:  ${RSS_ONLY}"
+echo ""
+
+# ── Step 1: Generate benchmark data ──────────────────────────────────────────
+if [[ -f "$LEFT_CSV" && -f "$RIGHT_CSV" ]]; then
+  L_SIZE=$(du -sh "$LEFT_CSV"  2>/dev/null | cut -f1 || echo "?")
+  R_SIZE=$(du -sh "$RIGHT_CSV" 2>/dev/null | cut -f1 || echo "?")
+  echo "==> [1/4] Using existing data files"
+  echo "    left.csv:  ${L_SIZE}   ${LEFT_CSV}"
+  echo "    right.csv: ${R_SIZE}   ${RIGHT_CSV}"
+  echo "    (delete files and re-run to regenerate)"
+elif [[ "$SKIP_GEN" == "true" ]]; then
+  echo "ERROR: --skip-gen set but ${DATA_DIR}/{left,right}.csv not found." >&2
+  echo "       Run: go run scripts/gen_bench_data.go --rows ${ROWS} --out ${DATA_DIR}" >&2
+  exit 1
+else
+  echo "==> [1/4] Generating ${ROWS} rows per side..."
+  go run "${SCRIPT_DIR}/gen_bench_data.go" --rows "$ROWS" --out "$DATA_DIR"
+fi
+echo ""
+
+# ── Step 2: Build binary ──────────────────────────────────────────────────────
+echo "==> [2/4] Building reconify binary..."
+go build -o "$BINARY" "${REPO_ROOT}/cmd/reconify"
+echo "    ${BINARY}"
+echo ""
+
+# ── Step 3: Go test benchmarks (warm cache) ───────────────────────────────────
+if [[ "$RSS_ONLY" == "false" ]]; then
+  echo "==> [3/4] Go benchmarks (warm OS page cache)"
+  echo ""
+  echo "    ── ParseCSVEach (synthetic, in-process files) ──"
+  go test \
+    -run='^$' \
+    -bench='BenchmarkParseCSVEach' \
+    -benchmem \
+    -benchtime=3s \
+    -count=1 \
+    "${REPO_ROOT}/engine/..." 2>&1
+
+  echo ""
+  echo "    ── ReconcileStreaming (synthetic 100k/1M) ──"
+  go test \
+    -run='^$' \
+    -bench='BenchmarkReconcileStreaming_100k|BenchmarkReconcileStreaming_1M$' \
+    -benchmem \
+    -benchtime=1x \
+    -timeout=300s \
+    -count=1 \
+    "${REPO_ROOT}/engine/..." 2>&1
+
+  echo ""
+  echo "    ── ReconcileStreaming_20M (realistic mixed, large-file) ──"
+  echo "    Note: runs -benchtime=1x (single iteration) due to file size."
+  echo "    Expected: ~60–120 s depending on storage speed."
+  BENCH_DATA_DIR="$DATA_DIR" \
+  go test \
+    -run='^$' \
+    -bench='BenchmarkReconcileStreaming_20M|BenchmarkParseCSVEach_20M' \
+    -benchmem \
+    -benchtime=1x \
+    -timeout=600s \
+    -count=1 \
+    "${REPO_ROOT}/engine/..." 2>&1
+
+  echo ""
+else
+  echo "==> [3/4] Skipped (--rss-only)"
+  echo ""
+fi
+
+# ── Step 4: Peak RSS + GC trace ───────────────────────────────────────────────
+
+# Write reconify.yaml for the bench pair.
+# Uses different column names for left (bank) vs right (payment processor)
+# to match the generated CSV schemas.
+cat > "$CONFIG_YAML" <<YAML
+version: 1
+timezone: UTC
+
+sources:
+  bank:
+    file_pattern: "${LEFT_CSV}"
+    parser:
+      type: csv
+      date_col: date
+      date_layout: "2006-01-02"
+      amount_col: amount
+      multiplier: 1
+      currency_col: currency
+      ref_col: ref_id
+      name_col: description
+      skip_raw: true
+
+  processor:
+    file_pattern: "${RIGHT_CSV}"
+    parser:
+      type: csv
+      date_col: txn_date
+      date_layout: "2006-01-02"
+      amount_col: txn_amount
+      multiplier: 1
+      currency_col: txn_currency
+      ref_col: txn_ref
+      name_col: merchant
+      skip_raw: true
+
+pairs:
+  bench:
+    left: bank
+    right: processor
+    amount_tolerance_minor: 0
+YAML
+
+# Optionally drop OS page cache for cold-I/O measurement.
+if [[ "$COLD_CACHE" == "true" ]]; then
+  echo "==> Dropping OS page cache (--cold)..."
+  if [[ "$PLATFORM" == "Darwin" ]]; then
+    if command -v purge &>/dev/null; then
+      sudo purge 2>/dev/null && echo "    page cache cleared via purge" \
+        || echo "    purge failed (sudo required); continuing with warm cache"
+    else
+      echo "    'purge' not found; continuing with warm cache"
+    fi
+  elif [[ "$PLATFORM" == "Linux" ]]; then
+    if [[ -w /proc/sys/vm/drop_caches ]]; then
+      sync
+      echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
+      echo "    page cache dropped"
+    else
+      echo "    /proc/sys/vm/drop_caches not writable; continuing with warm cache"
+    fi
+  fi
+  echo ""
+fi
+
+echo "==> [4/4] Peak RSS + GC trace  (${ROWS} rows × 2 sides)"
+echo "    format: ndjson (O(1) output)  GODEBUG=gctrace=1"
+echo ""
+
+if [[ "$PLATFORM" == "Darwin" ]]; then
+  # macOS: /usr/bin/time -l reports "maximum resident set size" in bytes
+  GODEBUG=gctrace=1 \
+    /usr/bin/time -l \
+    "$BINARY" reconcile \
+      --config  "$CONFIG_YAML" \
+      --pair    bench \
+      --format  ndjson \
+      --out     /dev/null \
+    2>&1 | tee "$GC_LOG"
+
+  echo ""
+  echo "==> Peak RSS (macOS):"
+  grep -i "maximum resident" "$GC_LOG" | tail -1 || echo "  (not found)"
+
+else
+  # Linux: /usr/bin/time -v reports "Maximum resident set size (kbytes)"
+  GODEBUG=gctrace=1 \
+    /usr/bin/time -v \
+    "$BINARY" reconcile \
+      --config  "$CONFIG_YAML" \
+      --pair    bench \
+      --format  ndjson \
+      --out     /dev/null \
+    2>&1 | tee "$GC_LOG"
+
+  echo ""
+  echo "==> Peak RSS (Linux):"
+  grep -i "maximum resident" "$GC_LOG" | tail -1 || echo "  (not found)"
+fi
+
+echo ""
+echo "==> GC summary:"
+GC_COUNT=$(grep -c "^gc " "$GC_LOG" 2>/dev/null || true)
+GC_COUNT="${GC_COUNT:-0}"
+echo "    GC cycles fired: ${GC_COUNT}"
+if [[ "$GC_COUNT" -gt 50 ]]; then
+  echo "    WARNING: high GC pressure. Consider increasing GOGC or using a disk-backed index."
+fi
+
+echo ""
+echo "    Full output saved to: ${GC_LOG}"
+echo ""
+header "Benchmark complete"

--- a/scripts/bench_rss.sh
+++ b/scripts/bench_rss.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# bench_rss.sh — measure peak RSS and GC behaviour for a 1M-row reconciliation run.
+#
+# Usage:
+#   ./scripts/bench_rss.sh [rows]
+#
+# Requirements:
+#   - reconify binary must be built: go build -o /tmp/reconify-bench ./cmd/reconify
+#   - reconify.yaml with a "bench" pair configured, OR this script generates one
+#
+# The script:
+#   1. Generates two synthetic 1M-row CSV files (left and right)
+#   2. Runs reconify reconcile with --format=ndjson (streaming, O(1) output)
+#   3. Reports peak RSS using platform-appropriate tools
+#   4. Enables GODEBUG=gctrace=1 to expose GC churn
+#
+# Cross-platform:
+#   macOS  — uses /usr/bin/time -l (reports "maximum resident set size")
+#   Linux  — uses /usr/bin/time -v (reports "Maximum resident set size")
+
+set -euo pipefail
+
+ROWS="${1:-1000000}"
+TMPDIR_BENCH="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BENCH"' EXIT
+
+echo "==> bench_rss: generating ${ROWS} synthetic rows..."
+
+LEFT_CSV="$TMPDIR_BENCH/left.csv"
+RIGHT_CSV="$TMPDIR_BENCH/right.csv"
+CONFIG_YAML="$TMPDIR_BENCH/reconify.yaml"
+BINARY="/tmp/reconify-bench"
+
+# Build binary if needed
+if [[ ! -f "$BINARY" ]]; then
+  echo "==> Building reconify binary..."
+  go build -o "$BINARY" "$(dirname "$0")/../cmd/reconify"
+fi
+
+# Generate synthetic CSV files
+python3 - <<PYEOF
+import csv, random, sys
+
+rows = $ROWS
+dates = ["2024-01-{:02d}".format(d) for d in range(1, 29)]
+
+def write_csv(path, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["date", "amount", "currency", "reference", "name"])
+        for i in range(rows):
+            w.writerow([
+                dates[i % len(dates)],
+                "{}.{:02d}".format(100 + i % 10000, i % 100),
+                "USD",
+                "REF{:010d}".format(i),
+                "Merchant {}".format(i % 500),
+            ])
+
+write_csv("$LEFT_CSV", rows)
+write_csv("$RIGHT_CSV", rows)
+print(f"Generated {rows} rows each side", file=sys.stderr)
+PYEOF
+
+# Write a minimal reconify.yaml for the bench pair
+cat > "$CONFIG_YAML" <<YAML
+version: 1
+timezone: UTC
+
+sources:
+  left:
+    file_pattern: "$LEFT_CSV"
+    parser:
+      type: csv
+      date_col: date
+      date_layout: "2006-01-02"
+      amount_col: amount
+      multiplier: 100
+      currency_col: currency
+      ref_col: reference
+      name_col: name
+      skip_raw: true
+
+  right:
+    file_pattern: "$RIGHT_CSV"
+    parser:
+      type: csv
+      date_col: date
+      date_layout: "2006-01-02"
+      amount_col: amount
+      multiplier: 100
+      currency_col: currency
+      ref_col: reference
+      name_col: name
+      skip_raw: true
+
+pairs:
+  bench:
+    left: left
+    right: right
+    amount_tolerance_minor: 0
+YAML
+
+echo "==> Running reconciliation with GODEBUG=gctrace=1 (${ROWS} rows each side)..."
+echo ""
+
+GC_LOG="$TMPDIR_BENCH/gctrace.txt"
+PLATFORM="$(uname -s)"
+
+if [[ "$PLATFORM" == "Darwin" ]]; then
+  # macOS: /usr/bin/time -l reports "maximum resident set size" in bytes
+  GODEBUG=gctrace=1 \
+    /usr/bin/time -l \
+    "$BINARY" reconcile \
+      --config "$CONFIG_YAML" \
+      --pair bench \
+      --format ndjson \
+      --out /dev/null \
+    2>&1 | tee "$GC_LOG"
+
+  echo ""
+  echo "==> Peak RSS (macOS):"
+  grep -i "maximum resident" "$GC_LOG" || true
+
+else
+  # Linux: /usr/bin/time -v reports "Maximum resident set size (kbytes)"
+  GODEBUG=gctrace=1 \
+    /usr/bin/time -v \
+    "$BINARY" reconcile \
+      --config "$CONFIG_YAML" \
+      --pair bench \
+      --format ndjson \
+      --out /dev/null \
+    2>&1 | tee "$GC_LOG"
+
+  echo ""
+  echo "==> Peak RSS (Linux):"
+  grep -i "maximum resident" "$GC_LOG" || true
+fi
+
+echo ""
+echo "==> GC events (summary):"
+grep -c "^gc " "$GC_LOG" 2>/dev/null && \
+  echo "GC cycles fired. Review $GC_LOG for full trace." || \
+  echo "(no GC trace lines found)"
+
+echo ""
+echo "Done. Full output saved to $GC_LOG"

--- a/scripts/gen_bench_data.go
+++ b/scripts/gen_bench_data.go
@@ -1,0 +1,300 @@
+//go:build ignore
+
+// gen_bench_data generates two synthetic CSV files for reconciliation benchmarking.
+//
+// Usage:
+//
+//	go run scripts/gen_bench_data.go [flags]
+//
+// Flags:
+//
+//	-rows int   Rows per file (default 20000000)
+//	-out  dir   Output directory (default /tmp/bench-data)
+//
+// Output:
+//
+//	<out>/left.csv   — bank/ledger format:      date,description,amount,ref_id,currency
+//	<out>/right.csv  — payment processor format: txn_date,txn_amount,txn_ref,merchant,txn_currency
+//
+// The two files intentionally use different column names to exercise the
+// CSVParserCfg field mapping (date_col, amount_col, ref_col, name_col).
+//
+// Row distribution (default 20M rows per side):
+//
+//	85% (17M) matched:      same ref, same amount, same date on both sides
+//	 5%  (1M) amount diff:  same ref + date; right amount is +1 to +50 minor units higher
+//	 5%  (1M) timing diff:  same ref + amount; right date is +1 to +3 days later
+//	 5%  (1M) left-only:    ref appears only in left.csv (unmatched left)
+//	 5%  (1M) right-only:   ref appears only in right.csv (unmatched right)
+//
+// Amounts are written as integers (minor units). Use multiplier: 1 in the
+// reconify config to consume these files without unit conversion.
+//
+// Date strings cycle over 730 unique values (2 calendar years). Because the
+// parser's date cache holds up to 1000 unique keys, the cache stays fully warm
+// for all 20M rows — matching real financial files where dates repeat daily.
+//
+// After generation the script prints the exact go test command to run the
+// large-file benchmarks.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const wbufSize = 4 << 20 // 4 MB write buffer
+
+func main() {
+	rows   := flag.Int("rows", 20_000_000, "rows per file")
+	outDir := flag.String("out", "/tmp/bench-data", "output directory")
+	flag.Parse()
+
+	n         := *rows
+	nMatch    := int(float64(n) * 0.85)
+	nAmtDiff  := int(float64(n) * 0.05)
+	nTimeDiff := int(float64(n) * 0.05)
+	nUnmatchL := n - nMatch - nAmtDiff - nTimeDiff // remainder goes to unmatched-left
+	nUnmatchR := int(float64(n) * 0.05)
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		log.Fatalf("mkdir %s: %v", *outDir, err)
+	}
+
+	// Precompute 730 date strings (2 calendar years: 2023-01-01 … 2024-12-31).
+	// 730 < 1000 (the parser's date-cache cap), so the cache stays warm throughout.
+	base  := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	dates := make([]string, 730)
+	for d := range dates {
+		dates[d] = base.AddDate(0, 0, d).Format("2006-01-02")
+	}
+
+	// Precompute 500 merchant name strings.
+	merchants := make([]string, 500)
+	for i := range merchants {
+		merchants[i] = "Merchant " + strconv.Itoa(i)
+	}
+
+	leftPath  := filepath.Join(*outDir, "left.csv")
+	rightPath := filepath.Join(*outDir, "right.csv")
+
+	lf, err := os.Create(leftPath)
+	if err != nil {
+		log.Fatalf("create left.csv: %v", err)
+	}
+	rf, err := os.Create(rightPath)
+	if err != nil {
+		log.Fatalf("create right.csv: %v", err)
+	}
+
+	lw := bufio.NewWriterSize(lf, wbufSize)
+	rw := bufio.NewWriterSize(rf, wbufSize)
+
+	lw.WriteString("date,description,amount,ref_id,currency\n")
+	rw.WriteString("txn_date,txn_amount,txn_ref,merchant,txn_currency\n")
+
+	log.Printf("generating %d rows per side", n)
+	log.Printf("  matched=%d  amount-diff=%d  timing-diff=%d  left-only=%d  right-only=%d",
+		nMatch, nAmtDiff, nTimeDiff, nUnmatchL, nUnmatchR)
+
+	start := time.Now()
+
+	// Reusable row byte slices — backed arrays grow once and are reused every row,
+	// avoiding per-row heap allocation in the generator itself.
+	var lb, rb []byte
+
+	// appendPaddedInt appends i zero-padded to exactly w decimal digits.
+	appendPaddedInt := func(b []byte, i, w int) []byte {
+		s := strconv.AppendInt(nil, int64(i), 10)
+		for pad := w - len(s); pad > 0; pad-- {
+			b = append(b, '0')
+		}
+		return append(b, s...)
+	}
+
+	// appendRef appends  prefix + "-" + 12-digit-zero-padded index.
+	// Examples: appendRef(b, "TXN", 0) → "TXN-000000000000"
+	//           appendRef(b, "ADIFF", 999999) → "ADIFF-000000999999"
+	appendRef := func(b []byte, prefix string, i int) []byte {
+		b = append(b, prefix...)
+		b = append(b, '-')
+		return appendPaddedInt(b, i, 12)
+	}
+
+	progress := func(done int) {
+		if done%1_000_000 == 0 {
+			log.Printf("  %3d M rows done  (%v elapsed)",
+				done/1_000_000, time.Since(start).Round(time.Millisecond))
+		}
+	}
+
+	// ── 1. Perfect matches ─────────────────────────────────────────────────
+	// Both files get identical ref, amount, and date.
+	for i := 0; i < nMatch; i++ {
+		date   := dates[i%730]
+		amount := int64(100 + i%999901)
+
+		// left row:  date,description,amount,ref_id,currency
+		lb = lb[:0]
+		lb = append(lb, date...)
+		lb = append(lb, ",Payment "...)
+		lb = appendRef(lb, "TXN", i)
+		lb = append(lb, ',')
+		lb = strconv.AppendInt(lb, amount, 10)
+		lb = append(lb, ',')
+		lb = appendRef(lb, "TXN", i)
+		lb = append(lb, ",USD\n"...)
+		lw.Write(lb) //nolint:errcheck
+
+		// right row: txn_date,txn_amount,txn_ref,merchant,txn_currency
+		rb = rb[:0]
+		rb = append(rb, date...)
+		rb = append(rb, ',')
+		rb = strconv.AppendInt(rb, amount, 10)
+		rb = append(rb, ',')
+		rb = appendRef(rb, "TXN", i)
+		rb = append(rb, ',')
+		rb = append(rb, merchants[i%500]...)
+		rb = append(rb, ",USD\n"...)
+		rw.Write(rb) //nolint:errcheck
+
+		progress(i + 1)
+	}
+
+	// ── 2. Amount diffs ────────────────────────────────────────────────────
+	// Same ref + date; right amount is leftAmt + (1..50).
+	for i := 0; i < nAmtDiff; i++ {
+		date     := dates[i%730]
+		leftAmt  := int64(100 + i%999901)
+		rightAmt := leftAmt + int64(i%50) + 1
+
+		lb = lb[:0]
+		lb = append(lb, date...)
+		lb = append(lb, ",Payment "...)
+		lb = appendRef(lb, "ADIFF", i)
+		lb = append(lb, ',')
+		lb = strconv.AppendInt(lb, leftAmt, 10)
+		lb = append(lb, ',')
+		lb = appendRef(lb, "ADIFF", i)
+		lb = append(lb, ",USD\n"...)
+		lw.Write(lb) //nolint:errcheck
+
+		rb = rb[:0]
+		rb = append(rb, date...)
+		rb = append(rb, ',')
+		rb = strconv.AppendInt(rb, rightAmt, 10)
+		rb = append(rb, ',')
+		rb = appendRef(rb, "ADIFF", i)
+		rb = append(rb, ',')
+		rb = append(rb, merchants[i%500]...)
+		rb = append(rb, ",USD\n"...)
+		rw.Write(rb) //nolint:errcheck
+
+		progress(nMatch + i + 1)
+	}
+
+	// ── 3. Timing diffs ────────────────────────────────────────────────────
+	// Same ref + amount; right date is +1 to +3 days after left date.
+	// Index bounds: i%727 ∈ [0,726], i%3+1 ∈ [1,3] → max index 729 = len(dates)-1. ✓
+	for i := 0; i < nTimeDiff; i++ {
+		leftDate  := dates[i%727]
+		rightDate := dates[i%727+i%3+1]
+		amount    := int64(100 + i%999901)
+
+		lb = lb[:0]
+		lb = append(lb, leftDate...)
+		lb = append(lb, ",Payment "...)
+		lb = appendRef(lb, "TDIFF", i)
+		lb = append(lb, ',')
+		lb = strconv.AppendInt(lb, amount, 10)
+		lb = append(lb, ',')
+		lb = appendRef(lb, "TDIFF", i)
+		lb = append(lb, ",USD\n"...)
+		lw.Write(lb) //nolint:errcheck
+
+		rb = rb[:0]
+		rb = append(rb, rightDate...)
+		rb = append(rb, ',')
+		rb = strconv.AppendInt(rb, amount, 10)
+		rb = append(rb, ',')
+		rb = appendRef(rb, "TDIFF", i)
+		rb = append(rb, ',')
+		rb = append(rb, merchants[i%500]...)
+		rb = append(rb, ",USD\n"...)
+		rw.Write(rb) //nolint:errcheck
+
+		progress(nMatch + nAmtDiff + i + 1)
+	}
+
+	// ── 4. Unmatched left ──────────────────────────────────────────────────
+	// LONLY-* refs appear only in left.csv.
+	for i := 0; i < nUnmatchL; i++ {
+		date   := dates[i%730]
+		amount := int64(100 + i%999901)
+
+		lb = lb[:0]
+		lb = append(lb, date...)
+		lb = append(lb, ",Payment "...)
+		lb = appendRef(lb, "LONLY", i)
+		lb = append(lb, ',')
+		lb = strconv.AppendInt(lb, amount, 10)
+		lb = append(lb, ',')
+		lb = appendRef(lb, "LONLY", i)
+		lb = append(lb, ",USD\n"...)
+		lw.Write(lb) //nolint:errcheck
+
+		progress(nMatch + nAmtDiff + nTimeDiff + i + 1)
+	}
+
+	// ── 5. Unmatched right ─────────────────────────────────────────────────
+	// RONLY-* refs appear only in right.csv.
+	for i := 0; i < nUnmatchR; i++ {
+		date   := dates[i%730]
+		amount := int64(100 + i%999901)
+
+		rb = rb[:0]
+		rb = append(rb, date...)
+		rb = append(rb, ',')
+		rb = strconv.AppendInt(rb, amount, 10)
+		rb = append(rb, ',')
+		rb = appendRef(rb, "RONLY", i)
+		rb = append(rb, ',')
+		rb = append(rb, merchants[i%500]...)
+		rb = append(rb, ",USD\n"...)
+		rw.Write(rb) //nolint:errcheck
+	}
+
+	// Flush and close — explicit ordering: flush writer, then close file handle.
+	if err := lw.Flush(); err != nil {
+		log.Fatalf("flush left.csv: %v", err)
+	}
+	if err := lf.Close(); err != nil {
+		log.Fatalf("close left.csv: %v", err)
+	}
+	if err := rw.Flush(); err != nil {
+		log.Fatalf("flush right.csv: %v", err)
+	}
+	if err := rf.Close(); err != nil {
+		log.Fatalf("close right.csv: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	leftInfo, _  := os.Stat(leftPath)
+	rightInfo, _ := os.Stat(rightPath)
+
+	log.Printf("done in %v", elapsed.Round(time.Millisecond))
+	log.Printf("left.csv:  %4d MB  (%s)", leftInfo.Size()/1024/1024, leftPath)
+	log.Printf("right.csv: %4d MB  (%s)", rightInfo.Size()/1024/1024, rightPath)
+	log.Printf("")
+	log.Printf("next step — run large-file benchmarks:")
+	log.Printf("  BENCH_DATA_DIR=%s go test -run='^$' -bench=BenchmarkReconcileStreaming_20M \\", *outDir)
+	log.Printf("    -benchtime=1x -benchmem -timeout=600s ./engine/...")
+	log.Printf("")
+	log.Printf("or use the full benchmark suite:")
+	log.Printf("  ./scripts/bench_full.sh --data-dir %s", *outDir)
+}


### PR DESCRIPTION
…ormance docs

- Add ParseCSVEach streaming parser with 1 MB buffer and date cache
- Add RightIndex interface and compact memoryIndex (bucket with dateUnix int64, Reference omitted from struct, stored as map key only)
- Add ReconcileStreaming: two-pass streaming reconciliation with O(1) output memory
- Eliminate leftFirst/rightFirst map[string]Transaction (v5): replace with saturating uint8 counters and targeted collectDuplicates re-scan; 3.6x wall clock improvement and 44% TotalAlloc reduction at 20M x 20M rows
- Compact bucket struct (v6): store dateUnix int64 instead of time.Time, omit Reference; removes 40M pointer fields from GC scan graph at 20M rows; peak RSS 7.6 GB to 6.2 GB
- Add ResultWriter with five output formats: json, json-stream, ndjson, csv, table
- Add --format flag to parse and reconcile CLI commands
- Add benchmark suite: synthetic 100k/1M and realistic 20M x 20M tests
- Add scripts/gen_bench_data.go (20M row CSV generator) and bench_full.sh
- Add docs/performance/README.md: architecture diagrams, benchmark results, memory analysis, GC pressure explanation, and hardware sizing formula