### PR TITLE
Add cross-agent workflow docs

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,17 @@
+# Agent Workflows
+
+This directory contains tool-agnostic workflow instructions for AI coding agents working on Reconify.
+
+The canonical skills are:
+
+- `skills/reconify-cli/SKILL.md`
+- `skills/reconify-config/SKILL.md`
+- `skills/reconify-performance/SKILL.md`
+
+Tool-specific integrations should point back here:
+
+- `AGENTS.md` gives project orientation.
+- `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are short compatibility shims.
+- `.claude/skills/` and `.codex/skills/` contain thin skill adapters.
+
+Update canonical skills first. Only update adapters when a tool needs a different discovery path.

--- a/.agents/skills/reconify-cli/SKILL.md
+++ b/.agents/skills/reconify-cli/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: reconify-cli
+description: Work with the Reconify command-line interface. Use when an agent needs to inspect CLI commands, update CLI docs, add or change Cobra commands under internal/cli, run smoke checks, explain command behavior, or verify user-facing flags and output formats.
+---
+
+# Reconify CLI
+
+## Overview
+
+Use this skill for changes or explanations involving `cmd/reconify`, `internal/cli`, README CLI examples, or generated command output. Prefer inspecting the live Cobra help before documenting behavior.
+
+## Quick Checks
+
+Run the smallest command that proves the current behavior:
+
+```bash
+go run ./cmd/reconify --help
+go run ./cmd/reconify config --help
+go run ./cmd/reconify parse --help
+go run ./cmd/reconify reconcile --help
+go test ./...
+```
+
+Use `make test` only when race detection and coverage output are wanted; it is slower and writes `coverage.out`.
+
+## CLI Map
+
+- Root command: `cmd/reconify/main.go`
+- Cobra setup: `internal/cli/root.go`
+- Config commands: `internal/cli/config.go`
+- Parse command: `internal/cli/parse.go`
+- Reconcile command: `internal/cli/reconcile.go`
+- Public config model: `config/config.go`
+- Output writers: `engine/format.go`
+
+## Workflow
+
+1. Inspect the relevant `--help` output before changing docs or behavior.
+2. Trace the command into `internal/cli` and the public package it calls.
+3. Preserve existing stdout/stderr conventions: data goes to stdout or `--out`; progress, validation status, and parse counts go to stderr.
+4. Keep new flags non-breaking and explicit. Do not change defaults unless the user asks for a behavior change.
+5. Add or update CLI tests when behavior changes. For docs-only updates, verify examples still match help text.
+
+## Output Formats
+
+- `parse` supports `ndjson`, `csv`, `table`, and `json`.
+- `reconcile` supports `json`, `json-stream`, `ndjson`, `csv`, and `table`.
+- For large reconciliation jobs, recommend `ndjson` or `csv`; `json` and `table` buffer more data.
+- `--audit` is supported only for structured JSON-style outputs: `json`, `json-stream`, and `ndjson`.
+
+## Documentation Rules
+
+- Keep examples copy-pasteable from the repo root.
+- Prefer `go run ./cmd/reconify ...` in contributor docs and `reconify ...` in user docs.
+- If README examples mention imports, use the module path from `go.mod`: `github.com/reconifyhq/reconify`.

--- a/.agents/skills/reconify-cli/agents/openai.yaml
+++ b/.agents/skills/reconify-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reconify CLI"
+  short_description: "Work with the Reconify command-line interface."
+  default_prompt: "Inspect, document, or test the Reconify CLI."

--- a/.agents/skills/reconify-config/SKILL.md
+++ b/.agents/skills/reconify-config/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: reconify-config
+description: Create, validate, review, or document Reconify YAML configuration. Use when an agent works with reconify.yaml, examples/reconify.yaml, config/config.go, source parser mappings, pair rules, index backends, or config-related CLI commands.
+---
+
+# Reconify Config
+
+## Overview
+
+Use this skill when the task involves Reconify configuration shape, validation, examples, or source/pair setup. The source of truth is the Go model in `config/config.go`.
+
+## Source Of Truth
+
+- Config structs and validation: `config/config.go`
+- User example: `examples/reconify.yaml`
+- README quick-start config: `README.md`
+- Config CLI checks: `internal/cli/config.go`
+
+## Required Shape
+
+Every valid config needs:
+
+- `version: 1`
+- `sources` with at least one source
+- each source: `file_pattern` and a CSV `parser`
+- each parser: `type: csv`, `date_col`, `date_layout`, `amount_col`, and positive `multiplier`
+- each pair: `left`, `right`, optional `date_window`, non-negative `amount_tolerance_minor`, and `name_mode` of `none` or `tokens`
+
+Optional performance-related fields:
+
+- `index.backend`: `memory`, `disk`, or `auto`
+- `index.spill_dir`: directory for disk index temporary files
+- `index.auto_max_right_file_mb`: threshold for `auto`
+- `parser.skip_raw`: skip Raw map allocation on parsed transactions
+
+## Workflow
+
+1. Read `config/config.go` before adding fields or changing validation behavior.
+2. Keep YAML examples aligned with struct tags and validation rules.
+3. Validate structure with:
+
+```bash
+go run ./cmd/reconify config validate --config examples/reconify.yaml
+```
+
+4. When checking a real CSV, use:
+
+```bash
+go run ./cmd/reconify config check-source --config reconify.yaml --source bank --file data/bank/jan.csv
+```
+
+5. If a field is added, update `examples/reconify.yaml`, README snippets, and tests together.
+
+## YAML Guidance
+
+- Use source names that describe systems: `bank`, `stripe`, `ledger`.
+- Keep amounts in minor units after parsing; use `multiplier: 100` for decimal currencies.
+- Use Go time layouts such as `2006-01-02`, not strftime-style layouts.
+- Use `name_mode: tokens` only when reference matching alone is insufficient.
+- Use `index.backend: auto` for large right-side files where memory pressure is a concern.
+
+Do not invent config keys without adding typed fields and validation.

--- a/.agents/skills/reconify-config/agents/openai.yaml
+++ b/.agents/skills/reconify-config/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reconify Config"
+  short_description: "Create and validate Reconify YAML configuration."
+  default_prompt: "Create, inspect, or validate a Reconify config."

--- a/.agents/skills/reconify-performance/SKILL.md
+++ b/.agents/skills/reconify-performance/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: reconify-performance
+description: Benchmark, tune, or explain Reconify performance. Use when an agent works on large-file reconciliation, parser allocation behavior, index backends, streaming output formats, benchmark scripts, memory usage, or docs under docs/performance.
+---
+
+# Reconify Performance
+
+## Overview
+
+Use this skill for performance-sensitive work in the parser, reconciler, output writers, and index backends. Keep quick correctness tests separate from heavy benchmarks.
+
+## Performance Map
+
+- Parser streaming and allocation behavior: `engine/parser.go`
+- Reconciliation streaming and progress: `engine/reconciler.go`
+- Output writer memory behavior: `engine/format.go`
+- Right-side indexes: `engine/index.go`, `engine/index_disk.go`
+- Benchmark data and runners: `scripts/gen_bench_data.go`, `scripts/bench_full.sh`, `scripts/bench_rss.sh`
+- Performance docs: `docs/performance/README.md`
+
+## Quick Verification
+
+Use these before running heavier benchmarks:
+
+```bash
+go test ./engine ./config ./internal/cli
+go test -run Test -bench=BenchmarkParse -benchmem ./engine
+go test -run Test -bench=BenchmarkReconcile -benchmem ./engine
+```
+
+`make test` runs race detection and coverage across the repo. It is a correctness gate, not a benchmark.
+
+## Benchmark Workflow
+
+1. Establish a baseline before changing hot paths.
+2. Record the command, dataset size, output format, index backend, and Go version.
+3. Prefer streaming formats for large jobs: `ndjson`, `csv`, or `json-stream`.
+4. Use `index.backend: auto` or `disk` when the right-side file is large enough to risk memory pressure.
+5. Re-run the same benchmark after changes and compare allocations, ns/op, and peak RSS when available.
+6. Update `docs/performance/README.md` only with reproducible numbers and the exact command used.
+
+## Large-File CLI Patterns
+
+```bash
+go run ./cmd/reconify reconcile \
+  --config reconify.yaml \
+  --pair bank_vs_stripe \
+  --format ndjson \
+  --progress \
+  --out results.ndjson
+```
+
+Use `--deterministic` only with `--format=json` when stable diff output matters more than sort overhead. Use `--audit --audit-fixed-timestamp ...` when comparing byte-identical audit output.
+
+## Guardrails
+
+- Do not replace streaming paths with whole-file reads.
+- Do not benchmark `table` or default `json` for large jobs unless the task is specifically about buffered output.
+- Do not commit generated benchmark datasets or local result files unless the user asks for fixtures.

--- a/.agents/skills/reconify-performance/agents/openai.yaml
+++ b/.agents/skills/reconify-performance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reconify Performance"
+  short_description: "Benchmark and reason about Reconify performance."
+  default_prompt: "Run or interpret Reconify performance checks."

--- a/.claude/skills/reconify-cli/SKILL.md
+++ b/.claude/skills/reconify-cli/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-cli
+description: Work with the Reconify command-line interface. Use when changing or documenting Cobra commands, flags, output formats, CLI examples, or command smoke tests.
+---
+
+# Reconify CLI
+
+Open and follow `.agents/skills/reconify-cli/SKILL.md`. That file is the canonical workflow. Keep this Claude adapter short and do not duplicate the full instructions here.

--- a/.claude/skills/reconify-config/SKILL.md
+++ b/.claude/skills/reconify-config/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-config
+description: Create, validate, review, or document Reconify YAML configuration, parser mappings, pair rules, examples, and config CLI behavior.
+---
+
+# Reconify Config
+
+Open and follow `.agents/skills/reconify-config/SKILL.md`. That file is the canonical workflow. Keep this Claude adapter short and do not duplicate the full instructions here.

--- a/.claude/skills/reconify-performance/SKILL.md
+++ b/.claude/skills/reconify-performance/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-performance
+description: Benchmark, tune, or explain Reconify performance, large-file reconciliation, streaming output, parser allocation behavior, and index backends.
+---
+
+# Reconify Performance
+
+Open and follow `.agents/skills/reconify-performance/SKILL.md`. That file is the canonical workflow. Keep this Claude adapter short and do not duplicate the full instructions here.

--- a/.codex/skills/reconify-cli/SKILL.md
+++ b/.codex/skills/reconify-cli/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-cli
+description: Work with the Reconify command-line interface. Use when changing or documenting Cobra commands, flags, output formats, CLI examples, or command smoke tests.
+---
+
+# Reconify CLI
+
+Open and follow `.agents/skills/reconify-cli/SKILL.md`. That file is the canonical workflow. Keep this Codex adapter short and do not duplicate the full instructions here.

--- a/.codex/skills/reconify-config/SKILL.md
+++ b/.codex/skills/reconify-config/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-config
+description: Create, validate, review, or document Reconify YAML configuration, parser mappings, pair rules, examples, and config CLI behavior.
+---
+
+# Reconify Config
+
+Open and follow `.agents/skills/reconify-config/SKILL.md`. That file is the canonical workflow. Keep this Codex adapter short and do not duplicate the full instructions here.

--- a/.codex/skills/reconify-performance/SKILL.md
+++ b/.codex/skills/reconify-performance/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: reconify-performance
+description: Benchmark, tune, or explain Reconify performance, large-file reconciliation, streaming output, parser allocation behavior, and index backends.
+---
+
+# Reconify Performance
+
+Open and follow `.agents/skills/reconify-performance/SKILL.md`. That file is the canonical workflow. Keep this Codex adapter short and do not duplicate the full instructions here.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot Instructions
+
+Follow `AGENTS.md` for Reconify project context, commands, and safety rules.
+
+Use `.agents/skills/` as the canonical workflow source:
+
+- `.agents/skills/reconify-cli/SKILL.md` for CLI command and docs work.
+- `.agents/skills/reconify-config/SKILL.md` for YAML config work.
+- `.agents/skills/reconify-performance/SKILL.md` for benchmark, memory, and streaming work.
+
+Prefer exact repo-root commands from `AGENTS.md`. Keep generated files, binaries, local CSVs, coverage output, and private `*.local.yaml` configs out of commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Reconify Agent Guide
+
+Reconify is a Go CLI and library for reconciling financial CSV data across systems such as banks, PSPs, ledgers, and spreadsheets.
+
+## Start Here
+
+- Read `README.md` for user-facing setup and CLI examples.
+- Read `docs/engine/README.md` before changing matching behavior.
+- Read `docs/performance/README.md` before changing streaming, indexing, or large-file behavior.
+- Use canonical agent skills in `.agents/skills/` for repeatable workflows.
+
+## Repo Map
+
+- `cmd/reconify/`: CLI entrypoint.
+- `internal/cli/`: Cobra commands and flags.
+- `config/`: YAML config loading and validation.
+- `engine/`: parser, reconciliation engine, indexes, output writers, audit data.
+- `examples/reconify.yaml`: baseline config example.
+- `scripts/`: benchmark and performance data helpers.
+
+## Commands
+
+```bash
+go mod download
+go run ./cmd/reconify --help
+go run ./cmd/reconify reconcile --help
+go test ./...
+make test
+make lint
+make build
+```
+
+Use `go test ./...` for quick verification. Use `make test` when race detection and coverage output are needed.
+
+## CLI Conventions
+
+- Data output goes to stdout or `--out`.
+- Status, progress, and validation messages go to stderr.
+- `parse` formats: `ndjson`, `csv`, `table`, `json`.
+- `reconcile` formats: `json`, `json-stream`, `ndjson`, `csv`, `table`.
+- Prefer `ndjson` or `csv` for large reconciliation jobs.
+
+## Agent Skills
+
+Canonical skills live under `.agents/skills/` and are intentionally tool-agnostic:
+
+- `.agents/skills/reconify-cli/SKILL.md`
+- `.agents/skills/reconify-config/SKILL.md`
+- `.agents/skills/reconify-performance/SKILL.md`
+
+Tool-specific files should be thin adapters that point back to these canonical skills. Do not duplicate long workflow instructions across Codex, Claude, Gemini, and Copilot files.
+
+## Change Rules
+
+- Keep edits scoped to the requested behavior.
+- Do not rewrite public config keys, CLI flags, or output formats unless the task explicitly requires a breaking change.
+- Update README/examples/tests when user-facing CLI or config behavior changes.
+- Do not commit generated benchmark datasets, local CSVs, coverage files, binaries, or private `*.local.yaml` configs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Instructions
+
+Read `AGENTS.md` first. It is the canonical project orientation for Reconify.
+
+Use the reusable workflows in `.agents/skills/` when the task touches the CLI, config files, or performance work. Claude-specific skill adapters live in `.claude/skills/` and intentionally redirect to the canonical `.agents/skills/` files.
+
+Keep this file short. Project rules belong in `AGENTS.md`; reusable procedures belong in `.agents/skills/`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# Gemini Instructions
+
+Read `AGENTS.md` first. It is the canonical project orientation for Reconify.
+
+Reusable agent workflows live in `.agents/skills/`. Treat tool-specific files as adapters only; do not duplicate long instructions here.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Reconify ingests financial data from multiple sources (banks, PSPs, ledgers, spr
 ## Installation
 
 ```bash
-go install github.com/reconify/reconify/cmd/reconify@latest
+go install github.com/reconifyhq/reconify/cmd/reconify@latest
 ```
 
 Or download a pre-built binary from [Releases](https://github.com/ReconifyHQ/reconify/releases).
@@ -127,8 +127,8 @@ The `engine` and `config` packages are public and can be imported by other Go mo
 
 ```go
 import (
-    "github.com/reconify/reconify/config"
-    "github.com/reconify/reconify/engine"
+    "github.com/reconifyhq/reconify/config"
+    "github.com/reconifyhq/reconify/engine"
 )
 
 // Load config
@@ -151,6 +151,10 @@ For a managed experience with a web dashboard, async processing, multi-user auth
 ### Prerequisites
 
 - Go 1.24+
+
+### Agent Experience
+
+Reconify includes agent-facing project context in [AGENTS.md](AGENTS.md), tool-specific adapters for Claude, Codex, Gemini, and Copilot, and reusable workflows under [.agents/skills/](.agents/skills/). Use [llms.txt](llms.txt) as the compact index for AI tools.
 
 ### Build
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,42 @@
+# Reconify
+
+Reconify is a Go CLI and library for reconciling financial CSV data from banks, PSPs, ledgers, and spreadsheets.
+
+## Start
+
+- Project orientation: AGENTS.md
+- Human README: README.md
+- Contributor guide: CONTRIBUTING.md
+- CLI entrypoint: cmd/reconify/main.go
+- CLI commands: internal/cli/
+- Config model: config/config.go
+- Reconciliation engine: engine/
+- Example config: examples/reconify.yaml
+
+## Agent Workflows
+
+- Canonical skills: .agents/skills/
+- CLI workflow: .agents/skills/reconify-cli/SKILL.md
+- Config workflow: .agents/skills/reconify-config/SKILL.md
+- Performance workflow: .agents/skills/reconify-performance/SKILL.md
+
+## Tool Adapters
+
+- Claude: CLAUDE.md and .claude/skills/
+- Codex: AGENTS.md and .codex/skills/
+- Gemini: GEMINI.md
+- Copilot: .github/copilot-instructions.md
+
+## Commands
+
+- Quick tests: go test ./...
+- Race and coverage: make test
+- Lint: make lint
+- Build CLI: make build
+- Inspect CLI: go run ./cmd/reconify --help
+
+## Docs
+
+- Engine internals: docs/engine/README.md
+- Performance notes: docs/performance/README.md
+- Production readiness notes: docs/performance/PRODUCTION_READINESS_REPORT.md


### PR DESCRIPTION
Adds canonical agent guidance, llms.txt, and tool-agnostic Reconify workflow skills for CLI, config, and performance work. Adds thin Claude, Codex, Gemini, and Copilot adapters that point back to the canonical .agents workflows. Updates the README with an Agent Experience section and fixes the stale Go module path in install/import examples. Verified with go test ./..., example config validation, CLI help, and git diff checks.